### PR TITLE
Update Form.php

### DIFF
--- a/app/Models/Forms/Form.php
+++ b/app/Models/Forms/Form.php
@@ -137,8 +137,13 @@ class Form extends Model
 
     public function getViewsCountAttribute()
     {
-        return $this->views()->count() +
+        if(env('DB_CONNECTION') == 'pgsql') {
+            return $this->views()->count() +
             $this->statistics()->sum(DB::raw("cast(data->>'views' as integer)"));
+        } elseif(env('DB_CONNECTION') == 'mysql') {
+            return $this->views()->count() +
+            $this->statistics()->sum(DB::raw("json_extract(data, '$.views')")); // code to
+        }
     }
 
     public function setDescriptionAttribute($value)


### PR DESCRIPTION
getViewsCountAttribute is using a raw SQL statement that is specific to pgsql, it fails on MySQL/MariaDB.  Added a conditional to use mysql specific code to access data in the json array.  Crude, but no more so than the original?