### PR TITLE
feat(s3-aws): Implement use_path_style_endpoint for Minio usage 

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -63,6 +63,7 @@ return [
             'bucket' => env('AWS_BUCKET'),
             'url' => env('AWS_URL'),
             'endpoint' => env('AWS_ENDPOINT'),
+            'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
         ],
 
     ],

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -63,7 +63,7 @@ return [
             'bucket' => env('AWS_BUCKET'),
             'url' => env('AWS_URL'),
             'endpoint' => env('AWS_ENDPOINT'),
-            'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
+            'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', true),
         ],
 
     ],


### PR DESCRIPTION
Hello

I tryed to use the S3 Storage with Minio (open-source S3 platform), but the `aws path style` is problematic.

It would be nice if we can tweak that from ENV VAR.

Thank you 