### PR TITLE
feat: add support for MySQL

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -27,6 +27,24 @@ jobs:
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
+      mysql:
+        # Docker Hub image
+        image: mysql:8
+        # Provide the password for mysql
+        env:
+          MYSQL_ROOT_PASSWORD: test
+          MYSQL_DATABASE: test
+          MYSQL_USER: test
+          MYSQL_PASSWORD: test
+        # Set health checks to wait until mysql has started
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+        ports:
+          # Maps tcp port 3306 on service container to the host
+          - 3306:3306
 
     concurrency:
       group: 'run-tests'
@@ -35,8 +53,22 @@ jobs:
       fail-fast: true
       matrix:
         php: [ 8.2 ]
+        connection: [ pgsql, mysql ]
+        include:
+          - connection: pgsql
+            host: localhost
+            port: 5432
+            user: postgres
+            password: postgres
+            database: postgres
+          - connection: mysql
+            host: '127.0.0.1'
+            port: 3306
+            user: root
+            password: test
+            database: test
 
-    name: Run Feature & Unit tests (PHP ${{ matrix.php }})
+    name: Run Feature & Unit tests (PHP ${{ matrix.php }} - ${{ matrix.connection }})
 
     steps:
       - name: Checkout code
@@ -80,6 +112,13 @@ jobs:
 
       - name: Run tests (Unit and Feature)
         run: ./vendor/bin/pest -p
+        env:
+          DB_CONNECTION: ${{ matrix.connection }}
+          DB_HOST: ${{ matrix.host }}
+          DB_PORT: ${{ matrix.port }}
+          DB_DATABASE: ${{ matrix.database }}
+          DB_USERNAME: ${{ matrix.user }}
+          DB_PASSWORD: ${{ matrix.password }}
 
       - name: "Archive log results"
         if: always()

--- a/database/migrations/2021_05_19_140326_create_forms_table.php
+++ b/database/migrations/2021_05_19_140326_create_forms_table.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
@@ -22,14 +23,14 @@ class CreateFormsTable extends Migration
             $table->timestamps();
             $table->boolean('notifies')->default(false);
             $table->text('description')->nullable();
-            $table->text('submit_button_text')->default('Submit');
+            $table->text('submit_button_text')->default(new Expression("('Submit')"));
             $table->boolean('re_fillable')->default(false);
-            $table->text('re_fill_button_text')->default('Fill Again');
+            $table->text('re_fill_button_text')->default(new Expression("('Fill Again')"));
             $table->string('color')->default('#3B82F6');
             $table->boolean('uppercase_labels')->default(true);
             $table->boolean('no_branding')->default(false);
             $table->boolean('hide_title')->default(false);
-            $table->text('submitted_text')->default('Amazing, we saved your answers. Thank you for your time and have a great day!');
+            $table->text('submitted_text')->default(new Expression("('Amazing, we saved your answers. Thank you for your time and have a great day!')"));
             $table->string('dark_mode')->default('auto');
             $table->string('webhook_url')->nullable();
             $table->boolean('send_submission_confirmation')->default(false);
@@ -45,13 +46,13 @@ class CreateFormsTable extends Migration
             $table->timestamp('closes_at')->nullable();
             $table->text('closed_text')->nullable();
             $table->string('notification_subject')->default("We saved your answers");
-            $table->text('notification_body')->default('<p>Hello there 👋 <br>This is a confirmation that your submission was successfully saved.</p>');
+            $table->text('notification_body')->default(new Expression("('<p>Hello there 👋 <br>This is a confirmation that your submission was successfully saved.</p>')"));
             $table->boolean('notifications_include_submission')->default(true);
             $table->boolean('use_captcha')->default(false);
             $table->boolean('can_be_indexed')->default(true);
             $table->string('password')->nullable()->default(null);
             $table->string('notification_sender')->default("OpenForm");
-            $table->jsonb('tags')->default('[]');
+            $table->jsonb('tags')->default(new Expression('(JSON_ARRAY())'));
         });
     }
 

--- a/database/migrations/2021_05_24_234028_create_form_submissions_table.php
+++ b/database/migrations/2021_05_24_234028_create_form_submissions_table.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
@@ -16,7 +17,7 @@ class CreateFormSubmissionsTable extends Migration
         Schema::create('form_submissions', function (Blueprint $table) {
             $table->id();
             $table->foreignIdFor(\App\Models\Forms\Form::class,'form_id');
-            $table->jsonb('data')->default('{}');
+            $table->jsonb('data')->default(new Expression("(JSON_OBJECT())"));
             $table->timestamps();
         });
     }

--- a/database/migrations/2022_05_10_144947_form_statistic.php
+++ b/database/migrations/2022_05_10_144947_form_statistic.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
@@ -16,7 +17,7 @@ return new class extends Migration
         Schema::create('form_statistics', function (Blueprint $table) {
             $table->id();
             $table->foreignIdFor(\App\Models\Forms\Form::class,'form_id');
-            $table->jsonb('data')->default('{}');
+            $table->jsonb('data')->default(new Expression("(JSON_OBJECT())"));
             $table->date('date');
         });
     }

--- a/database/migrations/2022_08_18_133641_add_removed_properties_to_forms.php
+++ b/database/migrations/2022_08_18_133641_add_removed_properties_to_forms.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
@@ -14,7 +15,7 @@ return new class extends Migration
     public function up()
     {
         Schema::table('forms', function (Blueprint $table) {
-            $table->jsonb('removed_properties')->default('[]');
+            $table->jsonb('removed_properties')->default(new Expression("(JSON_ARRAY())"));
         });
     }
 

--- a/database/migrations/2022_09_22_092205_create_templates_table.php
+++ b/database/migrations/2022_09_22_092205_create_templates_table.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
@@ -20,7 +21,7 @@ return new class extends Migration
             $table->string('slug');
             $table->text('description');
             $table->string('image_url');
-            $table->jsonb('structure')->default('{}');
+            $table->jsonb('structure')->default(new Expression("(JSON_OBJECT())"));
         });
     }
 

--- a/database/migrations/2022_09_26_084721_add_questions_to_templates.php
+++ b/database/migrations/2022_09_26_084721_add_questions_to_templates.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
@@ -14,7 +15,7 @@ return new class extends Migration
     public function up()
     {
         Schema::table('templates', function (Blueprint $table) {
-            $table->jsonb('questions')->default('{}');
+            $table->jsonb('questions')->default(new Expression("(JSON_ARRAY())"));
         });
     }
 

--- a/database/migrations/2023_03_13_094806_add_editable_submissions_button_text_to_forms.php
+++ b/database/migrations/2023_03_13_094806_add_editable_submissions_button_text_to_forms.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
@@ -14,7 +15,7 @@ return new class extends Migration
     public function up()
     {
         Schema::table('forms', function (Blueprint $table) {
-            $table->text('editable_submissions_button_text')->default('Edit submission');
+            $table->text('editable_submissions_button_text')->default(new Expression("('Edit submission')"));
         });
     }
 

--- a/database/migrations/2023_07_20_073728_add_seo_meta_to_forms.php
+++ b/database/migrations/2023_07_20_073728_add_seo_meta_to_forms.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
@@ -14,7 +15,7 @@ return new class extends Migration
     public function up()
     {
         Schema::table('forms', function (Blueprint $table) {
-            $table->json('seo_meta')->default('{}');
+            $table->json('seo_meta')->default(new Expression("(JSON_OBJECT())"));
         });
     }
 

--- a/database/migrations/2023_08_23_100710_add_notification_settings_to_forms.php
+++ b/database/migrations/2023_08_23_100710_add_notification_settings_to_forms.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
@@ -14,7 +15,7 @@ return new class extends Migration
     public function up()
     {
         Schema::table('forms', function (Blueprint $table) {
-            $table->json('notification_settings')->default('{}')->nullable(true);
+            $table->json('notification_settings')->default(new Expression("(JSON_OBJECT())"))->nullable(true);
         });
     }
 

--- a/database/migrations/2023_09_01_052507_add_fields_to_templates.php
+++ b/database/migrations/2023_09_01_052507_add_fields_to_templates.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
@@ -15,10 +16,10 @@ return new class extends Migration
     {
         Schema::table('templates', function (Blueprint $table) {
             $table->boolean('publicly_listed')->default(false);
-            $table->jsonb('industries')->default('[]');
-            $table->jsonb('types')->default('[]');
+            $table->jsonb('industries')->default(new Expression("(JSON_ARRAY())"));
+            $table->jsonb('types')->default(new Expression("(JSON_ARRAY())"));
             $table->string('short_description')->nullable();
-            $table->jsonb('related_templates')->default('[]');
+            $table->jsonb('related_templates')->default(new Expression("(JSON_ARRAY())"));
             $table->string('image_url',500)->nullable()->change();
         });
     }


### PR DESCRIPTION
This PR adds support for MySQL 8 and closes #171.

- [x] Updates the migrations to support default values for `TEXT`, `JSON`, and `JSONB` column types.
- [x] Updates the `.github/workflows/laravel.yml` workflow to run the tests with both **MySQL** and **PostgreSQL**.

Relevant documentation: 

- [11.6 Data Type Default Values (dev.mysql.com)](https://dev.mysql.com/doc/refman/8.0/en/data-type-defaults.html#data-type-defaults.html%23data-type-defaults-explicit)

/claim #171