### PR TITLE
fix: migrations not passing on pgsql

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -12,7 +12,7 @@ jobs:
     services:
       postgres:
         # Docker Hub image
-        image: postgres
+        image: postgres:14
         # Provide the password for postgres
         env:
           POSTGRES_PASSWORD: postgres

--- a/database/migrations/2021_05_19_140326_create_forms_table.php
+++ b/database/migrations/2021_05_19_140326_create_forms_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 class CreateFormsTable extends Migration
@@ -14,7 +15,9 @@ class CreateFormsTable extends Migration
      */
     public function up()
     {
-        Schema::create('forms', function (Blueprint $table) {
+        $driver = DB::getDriverName();
+
+        Schema::create('forms', function (Blueprint $table) use ($driver) {
             $table->id();
             $table->foreignIdFor(\App\Models\Workspace::class,'workspace_id');
             $table->string('title');
@@ -52,7 +55,11 @@ class CreateFormsTable extends Migration
             $table->boolean('can_be_indexed')->default(true);
             $table->string('password')->nullable()->default(null);
             $table->string('notification_sender')->default("OpenForm");
-            $table->jsonb('tags')->default(new Expression('(JSON_ARRAY())'));
+            if ($driver === 'mysql') {
+                $table->jsonb('tags')->default(new Expression('(JSON_ARRAY())'));
+            } else {
+                $table->jsonb('tags')->default('[]');
+            }            
         });
     }
 

--- a/database/migrations/2021_05_24_234028_create_form_submissions_table.php
+++ b/database/migrations/2021_05_24_234028_create_form_submissions_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 class CreateFormSubmissionsTable extends Migration
@@ -14,10 +15,16 @@ class CreateFormSubmissionsTable extends Migration
      */
     public function up()
     {
-        Schema::create('form_submissions', function (Blueprint $table) {
+        $driver = DB::getDriverName();
+
+        Schema::create('form_submissions', function (Blueprint $table) use ($driver) {
             $table->id();
             $table->foreignIdFor(\App\Models\Forms\Form::class,'form_id');
-            $table->jsonb('data')->default(new Expression("(JSON_OBJECT())"));
+            if ($driver === 'mysql') {
+                $table->jsonb('data')->default(new Expression("(JSON_OBJECT())"));
+            } else {
+                $table->jsonb('data')->default("{}");
+            }
             $table->timestamps();
         });
     }

--- a/database/migrations/2022_05_10_144947_form_statistic.php
+++ b/database/migrations/2022_05_10_144947_form_statistic.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -14,10 +15,16 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::create('form_statistics', function (Blueprint $table) {
+        $driver = DB::getDriverName();
+
+        Schema::create('form_statistics', function (Blueprint $table) use ($driver) {
             $table->id();
             $table->foreignIdFor(\App\Models\Forms\Form::class,'form_id');
-            $table->jsonb('data')->default(new Expression("(JSON_OBJECT())"));
+            if ($driver === 'mysql') {
+                $table->jsonb('data')->default(new Expression("(JSON_OBJECT())"));
+            } else {
+                $table->jsonb('data')->default("{}");
+            }
             $table->date('date');
         });
     }

--- a/database/migrations/2022_08_18_133641_add_removed_properties_to_forms.php
+++ b/database/migrations/2022_08_18_133641_add_removed_properties_to_forms.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -14,8 +15,14 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('forms', function (Blueprint $table) {
-            $table->jsonb('removed_properties')->default(new Expression("(JSON_ARRAY())"));
+        $driver = DB::getDriverName();
+
+        Schema::table('forms', function (Blueprint $table) use ($driver) {
+            if ($driver === 'mysql') {
+                $table->jsonb('removed_properties')->default(new Expression("(JSON_ARRAY())"));
+            } else {
+                $table->jsonb('removed_properties')->default("[]");
+            }
         });
     }
 

--- a/database/migrations/2022_09_22_092205_create_templates_table.php
+++ b/database/migrations/2022_09_22_092205_create_templates_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -14,14 +15,20 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::create('templates', function (Blueprint $table) {
+        $driver = DB::getDriverName();
+
+        Schema::create('templates', function (Blueprint $table) use ($driver) {
             $table->id();
             $table->timestamps();
             $table->string('name');
             $table->string('slug');
             $table->text('description');
             $table->string('image_url');
-            $table->jsonb('structure')->default(new Expression("(JSON_OBJECT())"));
+            if ($driver === 'mysql') {
+                $table->jsonb('structure')->default(new Expression("(JSON_OBJECT())"));
+            } else {
+                $table->jsonb('structure')->default('{}');
+            }
         });
     }
 

--- a/database/migrations/2022_09_26_084721_add_questions_to_templates.php
+++ b/database/migrations/2022_09_26_084721_add_questions_to_templates.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -14,8 +15,14 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('templates', function (Blueprint $table) {
-            $table->jsonb('questions')->default(new Expression("(JSON_ARRAY())"));
+        $driver = DB::getDriverName();
+        
+        Schema::table('templates', function (Blueprint $table) use ($driver) {
+            if ($driver === 'mysql') {
+                $table->jsonb('questions')->default(new Expression("(JSON_ARRAY())"));
+            } else {
+                $table->jsonb('questions')->default('[]');
+            }
         });
     }
 

--- a/database/migrations/2023_07_20_073728_add_seo_meta_to_forms.php
+++ b/database/migrations/2023_07_20_073728_add_seo_meta_to_forms.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -14,8 +15,14 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('forms', function (Blueprint $table) {
-            $table->json('seo_meta')->default(new Expression("(JSON_OBJECT())"));
+        $driver = DB::getDriverName();
+        
+        Schema::table('forms', function (Blueprint $table) use ($driver) {
+            if ($driver === 'mysql') {
+                $table->json('seo_meta')->default(new Expression("(JSON_OBJECT())"));
+            } else {
+                $table->json('seo_meta')->default("{}");
+            }
         });
     }
 

--- a/database/migrations/2023_08_23_100710_add_notification_settings_to_forms.php
+++ b/database/migrations/2023_08_23_100710_add_notification_settings_to_forms.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -14,8 +15,14 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('forms', function (Blueprint $table) {
-            $table->json('notification_settings')->default(new Expression("(JSON_OBJECT())"))->nullable(true);
+        $driver = DB::getDriverName();
+
+        Schema::table('forms', function (Blueprint $table) use ($driver) {
+            if ($driver === 'mysql') {
+                $table->json('notification_settings')->default(new Expression("(JSON_OBJECT())"))->nullable(true);
+            } else {
+                $table->json('notification_settings')->default('{}')->nullable(true);
+            }
         });
     }
 

--- a/database/migrations/2023_09_01_052507_add_fields_to_templates.php
+++ b/database/migrations/2023_09_01_052507_add_fields_to_templates.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -14,12 +15,31 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('templates', function (Blueprint $table) {
+        $driver = DB::getDriverName();
+
+        Schema::table('templates', function (Blueprint $table) use ($driver) {
             $table->boolean('publicly_listed')->default(false);
-            $table->jsonb('industries')->default(new Expression("(JSON_ARRAY())"));
-            $table->jsonb('types')->default(new Expression("(JSON_ARRAY())"));
+
+            if ($driver === 'mysql') {
+                $table->jsonb('industries')->default(new Expression("(JSON_ARRAY())"));
+            } else {
+                $table->jsonb('industries')->default('[]');
+            }
+
+            if ($driver === 'mysql') {
+                $table->jsonb('types')->default(new Expression("(JSON_ARRAY())"));
+            } else {
+                $table->jsonb('types')->default('[]');
+            }
+
             $table->string('short_description')->nullable();
-            $table->jsonb('related_templates')->default(new Expression("(JSON_ARRAY())"));
+
+            if ($driver === 'mysql') {
+                $table->jsonb('related_templates')->default(new Expression("(JSON_ARRAY())"));
+            } else {
+                $table->jsonb('related_templates')->default('[]');
+            }
+            
             $table->string('image_url',500)->nullable()->change();
         });
     }


### PR DESCRIPTION
Not sure why, but it appears that the recently introduced MySQL has broken the PostgreSQL migrations. Since all tests passed, I was not expecting that, but here's a fix.
 
The affected migrations now run alternative code depending on the driver being used.

Fixes #241 

---

I'll dig more to see why the tests did not catch this.
