### PR TITLE
Split backend tests & client build

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  tests:
+  backend_tests:
     runs-on: ubuntu-latest
 
     services:
@@ -86,13 +86,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-composer-
 
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -128,6 +121,51 @@ jobs:
           path: storage/logs/laravel.log
           retention-days: 3
 
+  build_client:
+    runs-on: ubuntu-latest
+
+    name: Build front-end client
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, mbstring, pdo, sqlite, pdo_sqlite
+          tools: composer:v2
+          coverage: none
+
+      - name: Prepare the environment
+        run: cp .env.example .env
+
+      - name: Install composer dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress --ignore-platform-reqs --optimize-autoloader
+
+      - name: Directory permissions
+        run: chmod -R 777 storage bootstrap/cache
+
       - name: Install npm dependencies
         run: npm install --no-audit --no-progress --silent
 
@@ -135,7 +173,7 @@ jobs:
         run: npm run build
 
   production-deploy:
-    needs: [ tests ]
+    needs: [ tests, build_client ]
     if: success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
To speed things up a bit, build client in another test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed the job for backend testing to `backend_tests` for clarity.

- **New Features**
  - Introduced a new job `build_client` to handle building the front-end client.

- **Chores**
  - Updated the `production-deploy` job to include the new `build_client` job as a dependency, ensuring both backend tests and front-end build are completed before deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->