### PR TITLE
fix local files in docker

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -25,6 +25,16 @@ server {
               try_files $uri $uri/ /index.php$is_args$args;
          }
 
+         location /local/temp/ {
+              set $original_uri $uri;
+              try_files $uri $uri/ /index.php$is_args$args;
+         }
+
+         location /forms/assets/ {
+              set $original_uri $uri;
+              try_files $uri $uri/ /index.php$is_args$args;
+         }
+
          location ~ \.php$ {
             fastcgi_split_path_info ^(.+\.php)(/.+)$;
             fastcgi_pass unix:/var/run/php-fpm-opnform-site.sock;

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,7 +20,6 @@ use App\Http\Controllers\TemplateController;
 use App\Http\Controllers\WorkspaceController;
 use App\Http\Middleware\Form\ResolveFormMiddleware;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Storage;
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -227,10 +227,8 @@ Route::get('local/temp/{path}', function (Request $request, string $path) {
     if (! $request->hasValidSignature()) {
         abort(401);
     }
-    $response = Response::make(Storage::get($path), 200);
-    $response->header('Content-Type', Storage::mimeType($path));
 
-    return $response;
+    return response()->file(Storage::path($path), ['Content-Type' => Storage::mimeType($path)]);
 })->where('path', '(.*)')->name('local.temp');
 
 Route::get('caddy/ask-certificate/{secret?}', [\App\Http\Controllers\CaddyController::class, 'ask'])


### PR DESCRIPTION
`Response::make` doesn't exist anymore and the nginx.conf didnt allow the needed paths (`/local/temp/`, `/forms/assets/`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced server configuration to handle requests more efficiently for specific paths.
- **Refactor**
	- Improved the file serving functionality in the API for better code simplicity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->