### PR TITLE
fix zappier button link

### DIFF
--- a/client/components/open/forms/components/form-components/FormNotifications.vue
+++ b/client/components/open/forms/components/form-components/FormNotifications.vue
@@ -54,7 +54,7 @@ export default {
 
   computed: {
     zapierUrl () {
-      opnformConfig.links.zapier_integration
+      return opnformConfig.links.zapier_integration
     }
   },
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue where the Zapier integration URL was not properly displayed in form notifications settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->