### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/client/components/forms/ImageInput.vue
+++ b/client/components/forms/ImageInput.vue
@@ -144,7 +144,7 @@ export default {
   watch: {
     showUploadModal: {
       handler (val) {
-        if (process.server) return
+        if (import.meta.server) return
         document.removeEventListener('paste', this.onUploadPasteEvent)
         if (this.showUploadModal) {
           document.addEventListener('paste', this.onUploadPasteEvent)

--- a/client/components/global/Modal.vue
+++ b/client/components/global/Modal.vue
@@ -88,13 +88,13 @@ const closeOnEscape = (e) => {
 }
 
 onMounted(() => {
-  if (process.server) return
+  if (import.meta.server) return
   document.addEventListener('keydown', closeOnEscape)
   initMotions()
 })
 
 onBeforeUnmount(() => {
-  if (process.server) return
+  if (import.meta.server) return
   document.removeEventListener('keydown', closeOnEscape)
 })
 

--- a/client/components/global/Navbar.vue
+++ b/client/components/global/Navbar.vue
@@ -235,7 +235,7 @@ export default {
 
   methods: {
     openChangelog() {
-      if (process.server) return
+      if (import.meta.server) return
       window.Featurebase('manually_open_changelog_popup')
     },
     async logout() {

--- a/client/components/open/forms/OpenCompleteForm.vue
+++ b/client/components/open/forms/OpenCompleteForm.vue
@@ -152,7 +152,7 @@ export default {
 
   computed: {
     isEmbedPopup () {
-      return process.client && window.location.href.includes('popup=true')
+      return import.meta.client && window.location.href.includes('popup=true')
     },
     theme () {
       return this.themes[this.themes.hasOwnProperty(this.form.theme) ? this.form.theme : 'default']
@@ -161,7 +161,7 @@ export default {
       return this.$route.name === 'forms-slug'
     },
     isHideTitle () {
-      return this.form.hide_title || (process.client && window.location.href.includes('hide_title=true'))
+      return this.form.hide_title || (import.meta.client && window.location.href.includes('hide_title=true'))
     }
   },
 

--- a/client/components/open/forms/OpenForm.vue
+++ b/client/components/open/forms/OpenForm.vue
@@ -267,7 +267,7 @@ export default {
 
   mounted () {
     this.initForm()
-    if (process.client && window.location.href.includes('auto_submit=true')) {
+    if (import.meta.client && window.location.href.includes('auto_submit=true')) {
       this.isAutoSubmit = true
       this.submitForm()
     }
@@ -279,7 +279,7 @@ export default {
         return
       }
 
-      if (this.form.use_captcha && process.client) {
+      if (this.form.use_captcha && import.meta.client) {
         this.dataForm['h-captcha-response'] = document.getElementsByName('h-captcha-response')[0].value
         this.$refs.hcaptcha.reset()
       }
@@ -311,7 +311,7 @@ export default {
       }
 
       // Scroll to error
-      if (process.server) return
+      if (import.meta.server) return
       const elements = document.getElementsByClassName('has-error')
       if (elements.length > 0) {
         window.scroll({

--- a/client/components/open/forms/components/CopyContent.vue
+++ b/client/components/open/forms/components/CopyContent.vue
@@ -37,7 +37,7 @@ const props = defineProps({
 })
 
 const copyToClipboard = () => {
-  if (process.server) return
+  if (import.meta.server) return
   copy(props.content)
   if(props.isDraft){
     useAlert().warning('Copied! But other people won\'t be able to see the form since it\'s currently in draft mode')

--- a/client/components/open/forms/components/FormSubmissions.vue
+++ b/client/components/open/forms/components/FormSubmissions.vue
@@ -145,7 +145,7 @@ export default {
   },
   computed: {
     parentPage() {
-      if (process.server) {
+      if (import.meta.server) {
         return null
       }
       return window
@@ -261,7 +261,7 @@ export default {
       this.properties = columns
     },
     onChangeDisplayColumns() {
-      if (!process.client) return
+      if (!import.meta.client) return
       window.localStorage.setItem('display-columns-formid-' + this.form.id, JSON.stringify(this.displayColumns))
       this.properties = clonedeep(this.form.properties).concat(this.removed_properties).filter((field) => {
         return this.displayColumns[field.id] === true

--- a/client/components/open/forms/components/FormUrlPrefill.vue
+++ b/client/components/open/forms/components/FormUrlPrefill.vue
@@ -59,7 +59,7 @@ const preFillUrl = computed(() => {
 })
 
 const copyToClipboard = () => {
-  if (process.server) return
+  if (import.meta.server) return
   copy(preFillUrl.value)
   useAlert().success('Copied!')
 }

--- a/client/components/open/tables/components/ResizableTh.vue
+++ b/client/components/open/tables/components/ResizableTh.vue
@@ -32,7 +32,7 @@ export default {
 
   methods: {
     mouseDownHandler(e) {
-      if (process.server) return
+      if (import.meta.server) return
       // Get the current mouse position
       this.x = e.clientX
 

--- a/client/components/pages/forms/show/EmbedFormAsPopupModal.vue
+++ b/client/components/pages/forms/show/EmbedFormAsPopupModal.vue
@@ -150,12 +150,12 @@ const onClose = () => {
   showEmbedFormAsPopupModal.value = false
 }
 const copyToClipboard = () => {
-  if (process.server) return
+  if (import.meta.server) return
   copy(embedPopupCode.value)
   useAlert().success('Copied!')
 }
 const removePreview = () => {
-  if (process.server) return
+  if (import.meta.server) return
   const oldP = document.head.querySelector('#nf-popup-preview')
   if (oldP) {
     oldP.remove()
@@ -166,7 +166,7 @@ const removePreview = () => {
   }
 }
 const previewPopup = (nfData) => {
-  if (process.server) return
+  if (import.meta.server) return
   if (!showEmbedFormAsPopupModal.value) {
     return
   }

--- a/client/components/pages/welcome/Testimonials.vue
+++ b/client/components/pages/welcome/Testimonials.vue
@@ -33,7 +33,7 @@ export default {
 
   methods: {
     loadScript () {
-      if (process.server) return
+      if (import.meta.server) return
       const script = document.createElement('script')
       script.setAttribute('src', 'https://testimonial.to/js/iframeResizer.min.js')
       document.head.appendChild(script)

--- a/client/components/vendor/FeatureBase.vue
+++ b/client/components/vendor/FeatureBase.vue
@@ -18,7 +18,7 @@ const loadScript = () => {
 };
 
 const setupForUser = () => {
-  if (process.server || !user.value || !featureBaseOrganization ||isImpersonating.value) return
+  if (import.meta.server || !user.value || !featureBaseOrganization ||isImpersonating.value) return
   window.Featurebase(
     "identify",
     {
@@ -49,7 +49,7 @@ const setupForUser = () => {
 }
 
 onMounted(() => {
-  if (process.server) return
+  if (import.meta.server) return
 
   // Setup base
   if (!window.hasOwnProperty('Featurebase') || typeof window.Featurebase !== "function") {
@@ -64,7 +64,7 @@ onMounted(() => {
 })
 
 watch(user, (val) => {
-  if (process.server || !val) return
+  if (import.meta.server || !val) return
 
   loadScript()
   setupForUser()

--- a/client/composables/forms/pendingSubmission.js
+++ b/client/composables/forms/pendingSubmission.js
@@ -12,7 +12,7 @@ export const pendingSubmission = (form) => {
   })
 
   const set = (value) => {
-    if (process.server || !enabled.value) return
+    if (import.meta.server || !enabled.value) return
     useStorage(formPendingSubmissionKey.value).value = value === null ? value : JSON.stringify(value)
   }
 
@@ -21,7 +21,7 @@ export const pendingSubmission = (form) => {
   }
 
   const get = (defaultValue = {}) => {
-    if (process.server || !enabled.value) return
+    if (import.meta.server || !enabled.value) return
     const pendingSubmission = useStorage(formPendingSubmissionKey.value).value
     return pendingSubmission ? JSON.parse(pendingSubmission) : defaultValue
   }

--- a/client/composables/useCrisp.js
+++ b/client/composables/useCrisp.js
@@ -1,6 +1,6 @@
 export const useCrisp = () => {
 
-  let crisp = process.client ? window.Crisp : null
+  let crisp = import.meta.client ? window.Crisp : null
 
   function openChat() {
     if (!crisp) return

--- a/client/composables/useIsIframe.js
+++ b/client/composables/useIsIframe.js
@@ -1,5 +1,5 @@
 export const useIsIframe = () => {
-  if (process.client) {
+  if (import.meta.client) {
     return window.location !== window.parent.location || window.frameElement
   }
   return false

--- a/client/composables/useOpnApi.js
+++ b/client/composables/useOpnApi.js
@@ -39,7 +39,7 @@ export function getOpnRequestsOptions(request, opts) {
   opts.headers = {accept: 'application/json', ...opts.headers}
 
   // Authenticate requests coming from the server
-  if (process.server && config.apiSecret) {
+  if (import.meta.server && config.apiSecret) {
     opts.headers['x-api-secret'] = config.apiSecret
   }
 

--- a/client/lib/forms/public-page.js
+++ b/client/lib/forms/public-page.js
@@ -1,11 +1,11 @@
 
-let darkModeNodeParent = process.client ? document.body : null
+let darkModeNodeParent = import.meta.client ? document.body : null
 
 /**
  * Handle form public pages dark mode and transparent mode
  */
 export function handleDarkMode (darkMode, elem = null) {
-  if (process.server) return
+  if (import.meta.server) return
 
   darkModeNodeParent = elem ?? document.body
 
@@ -23,7 +23,7 @@ export function handleDarkMode (darkMode, elem = null) {
 }
 
 export function darkModeEnabled() {
-  if (process.server) return false
+  if (import.meta.server) return false
   return computed(() => document.body.classList.contains('dark'))
 }
 
@@ -36,7 +36,7 @@ function handleDarkModeToggle (enabled) {
 }
 
 export function disableDarkMode () {
-  if (process.server) return
+  if (import.meta.server) return
   const body = document.body
   body.classList.remove('dark')
   // Remove event listener
@@ -44,7 +44,7 @@ export function disableDarkMode () {
 }
 
 export function handleTransparentMode (transparentModeEnabled) {
-  if (process.server) return
+  if (import.meta.server) return
   if (!useIsIframe() || !transparentModeEnabled) return
 
   const app = document.getElementById('app')
@@ -54,7 +54,7 @@ export function handleTransparentMode (transparentModeEnabled) {
 }
 
 export function focusOnFirstFormElement() {
-  if (process.server) return
+  if (import.meta.server) return
   for (const ele of document.querySelectorAll('input,button,textarea,[role="button"]')) {
     if (ele.offsetWidth !== 0 || ele.offsetHeight !== 0) {
       ele.focus()

--- a/client/lib/utils.js
+++ b/client/lib/utils.js
@@ -62,7 +62,7 @@ export const appUrl = (path = '/') => {
  * @returns {string}
  */
 export const getHost = function () {
-  if (process.server) {
+  if (import.meta.server) {
     return getDomain(useNuxtApp().ssrContext?.event.context.siteConfigNitroOrigin) || useNuxtApp().ssrContext?.event.node.req.headers.host
   } else {
     return window.location.host

--- a/client/middleware/api-redirect.global.js
+++ b/client/middleware/api-redirect.global.js
@@ -1,6 +1,6 @@
 
 export default defineNuxtRouteMiddleware((to, from) => {
-  if (process.client) return
+  if (import.meta.client) return
 
   const config = useRuntimeConfig()
   if (to.fullPath.startsWith('/api')) {

--- a/client/middleware/custom-domain.global.js
+++ b/client/middleware/custom-domain.global.js
@@ -23,7 +23,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
   const config = useRuntimeConfig()
 
   const customDomainHeaderValue = useRequestHeaders()[customDomainHeaderName]
-  if (process.server && (!customDomainHeaderValue || customDomainHeaderValue !== getDomain(getHost()))) {
+  if (import.meta.server && (!customDomainHeaderValue || customDomainHeaderValue !== getDomain(getHost()))) {
     return redirectToMainDomain( {
       reason: 'header_mismatch',
       customDomainHeaderValue: customDomainHeaderValue,

--- a/client/pages/forms/[slug]/edit.vue
+++ b/client/pages/forms/[slug]/edit.vue
@@ -75,7 +75,7 @@ onBeforeRouteLeave((to, from, next) => {
 })
 
 onBeforeMount(() => {
-  if (process.client) {
+  if (import.meta.client) {
     window.onbeforeunload = () => {
       if (isDirty()) {
         return false

--- a/client/pages/forms/[slug]/index.vue
+++ b/client/pages/forms/[slug]/index.vue
@@ -121,7 +121,7 @@ onMounted(() => {
     handleDarkMode(form.value?.dark_mode)
     handleTransparentMode(form.value?.transparent_background)
 
-    if (process.client) {
+    if (import.meta.client) {
       if (form.value.custom_code) {
         const scriptEl = document.createRange().createContextualFragment(form.value.custom_code)
         try {

--- a/client/pages/forms/create/index.vue
+++ b/client/pages/forms/create/index.vue
@@ -80,7 +80,7 @@ watch(() => workspace, () => {
 })
 
 onMounted(() => {
-  if (process.client) {
+  if (import.meta.client) {
     window.onbeforeunload = () => {
       if (isDirty()) {
         return false

--- a/client/plugins/sentry.js
+++ b/client/plugins/sentry.js
@@ -2,7 +2,7 @@ import * as Sentry from "@sentry/vue";
 
 function getSentryIntegrations() {
   // don't load on server
-  if (!process.client) return [];
+  if (!import.meta.client) return [];
 
   const router = useRouter();
   const browserTracing = new Sentry.BrowserTracing({

--- a/client/stores/auth.js
+++ b/client/stores/auth.js
@@ -34,7 +34,7 @@ export const useAuthStore = defineStore('auth', {
     },
 
     setCookie(name, value) {
-      if (process.client) {
+      if (import.meta.client) {
         useCookie(name).value = value
       }
     },


### PR DESCRIPTION
This is a very early PR to make this app compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated environment detection logic across various components and utilities to use `import.meta` for better handling of server-side and client-side rendering.
	- Improved consistency in environment checks throughout the application, enhancing compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->