### PR TITLE
Issue 349/database not created

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,7 @@ FROM --platform=linux/amd64 ubuntu:23.04
 
 # supervisord is a process manager which will be responsible for managing the
 # various server processes.  These are configured in docker/supervisord.conf
-
-CMD ["/usr/bin/supervisord"]
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,8 +68,10 @@ RUN apt-get update \
         supervisor nginx sudo postgresql-15 redis\
         $PHP_PACKAGES php8.1-fpm wget\
     && apt-get clean
-RUN wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.39.3/install.sh | bash
-RUN . /root/.nvm/nvm.sh && nvm install 20
+
+RUN useradd nuxt && mkdir ~nuxt && chown nuxt ~nuxt
+RUN wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.39.3/install.sh | sudo -u nuxt bash
+RUN sudo -u nuxt bash -c ". ~nuxt/.nvm/nvm.sh && nvm install --no-progress 20"
 
 ADD docker/postgres-wrapper.sh docker/php-fpm-wrapper.sh docker/redis-wrapper.sh docker/nuxt-wrapper.sh docker/generate-api-secret.sh /usr/local/bin/
 ADD docker/php-fpm.conf /etc/php/8.1/fpm/pool.d/

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Custom Nuxt .env file:
 docker run --name opnform -v $PWD/custom-nuxt-env-file.env:/app/client/.env -v $PWD/my-opnform-data:/persist -p 80:80 jhumanj/opnform
 ```
 
-This would load load in the env file located at `my-custom-env-file.env`, note that if you are creating a .env file for use like this it's best to start from the `.docker.env` example file as there are slightly different defaults for the dockerized setup.
+This would load load in the env file located at `my-custom-env-file.env`, note that if you are creating a .env file for use like this it's best to start from the `.env.docker` example file as there are slightly different defaults for the dockerized setup.
 
 #### Using a custom HTTP port
 

--- a/docker/generate-api-secret.sh
+++ b/docker/generate-api-secret.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 main() {
     ( flock -n 100 || wait_for_other_instance; generate_api_secrets) 100> /var/lock/api_secret.lock

--- a/docker/generate-api-secret.sh
+++ b/docker/generate-api-secret.sh
@@ -6,9 +6,9 @@ main() {
 
 generate_api_secrets() {
 	if ! is_configured; then
-		SECRET=$(random_string)
-		add_secret_to_env_file /app/client/.env NUXT_API_SECRET $SECRET
-		add_secret_to_env_file /app/.env FRONT_API_SECRET $SECRET
+		SECRET="$(random_string)"
+		add_secret_to_env_file /app/client/.env NUXT_API_SECRET "$SECRET"
+		add_secret_to_env_file /app/.env FRONT_API_SECRET "$SECRET"
 	fi
 }
 
@@ -27,7 +27,7 @@ add_secret_to_env_file() {
 	VAR=$2
 	VAL=$3
 
-	grep "^$VAR=" $FILE || ( echo $VAR= >> $FILE )
+	grep "^$VAR=" "$FILE" || ( echo "$VAR=" >> "$FILE" )
 
 	cp $FILE $TEMP_FILE
 	sed "s/^$VAR=.*$/$VAR=$VAL/" -i $TEMP_FILE

--- a/docker/nuxt-wrapper.sh
+++ b/docker/nuxt-wrapper.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
-echo + . /root/.nvm/nvm.sh
-. /root/.nvm/nvm.sh
+echo + . ~nuxt/.nvm/nvm.sh
+. ~nuxt/.nvm/nvm.sh
 
 echo + nvm install --no-progress 20
 nvm install --no-progress 20
@@ -11,7 +11,7 @@ nvm use 20
 cd /app/nuxt/server/
 
 echo + . /app/client/.env
-. /app/client/.env
+[ -f /app/client/.env ] && . /app/client/.env || echo "Environment file missing!"
 
 [ "x$NUXT_API_SECRET" != "x" ] || (
   echo + generate-api-secret.sh

--- a/docker/nuxt-wrapper.sh
+++ b/docker/nuxt-wrapper.sh
@@ -1,15 +1,25 @@
-#!/bin/bash
+#!/bin/bash -e
 
+echo + . /root/.nvm/nvm.sh
 . /root/.nvm/nvm.sh
-nvm install 20
+
+echo + nvm install --no-progress 20
+nvm install --no-progress 20
+echo + nvm use 20
 nvm use 20
 
 cd /app/nuxt/server/
 
+echo + . /app/client/.env
 . /app/client/.env
 
-[ "x$NUXT_API_SECRET" != "x" ] || generate-api-secret.sh
+[ "x$NUXT_API_SECRET" != "x" ] || (
+  echo + generate-api-secret.sh
+    generate-api-secret.sh
+)
 
+echo + eval \$\(sed 's/^/export /' \< /app/client/.env\)
 eval $(sed 's/^/export /' < /app/client/.env)
 
+echo + node index.mjs
 node index.mjs

--- a/docker/php-fpm-wrapper.sh
+++ b/docker/php-fpm-wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash +ex
+#!/bin/bash -ex
 
 [ -L /app/storage ] || {
     echo "Backing up initial storage directory"
@@ -19,20 +19,25 @@ chown opnform /var/log/opnform.log
 echo "Linking persistent storage into app"
 ln -t /app -sf /persist/storage
 
-. /app/.env
+read_env() {
+    set +x
+    . /app/.env
+    set -x
+}
+read_env
 
 [ "x$APP_KEY" != "x" ] || {
     artisan key:generate
-    . /app/.env
+    read_env
 }
 [ "x$JWT_SECRET" != "x" ] || {
     artisan jwt:secret -f
-    . /app/.env
+    read_env
 }
 
 [ "x$FRONT_API_SECRET" != "x" ] || {
 	generate-api-secret.sh
-    . /app/.env
+    read_env
 }
 
 /usr/sbin/php-fpm8.1

--- a/docker/postgres-wrapper.sh
+++ b/docker/postgres-wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ex
 
 DATA_DIR=/persist/pgsql/data
 CONFIG_FILE=/etc/postgresql/postgresql.conf
@@ -10,7 +10,9 @@ mkdir -p $DATA_DIR
 chown postgres -R $DATA_DIR
 chmod 0700 $DATA_DIR
 
+set +x
 . /app/.env
+set -x
 
 test -f $DATA_DIR/postgresql.conf || NEW_DB=true
 

--- a/docker/postgres-wrapper.sh
+++ b/docker/postgres-wrapper.sh
@@ -43,6 +43,6 @@ EOF
 fi
 
 wait_for_database_to_be_ready
-artisan migrate --force
+sudo -u opnform artisan migrate --force
 
 wait

--- a/docker/postgres-wrapper.sh
+++ b/docker/postgres-wrapper.sh
@@ -43,6 +43,6 @@ EOF
 fi
 
 wait_for_database_to_be_ready
-artisan migrate
+artisan migrate --force
 
 wait

--- a/docker/redis-wrapper.sh
+++ b/docker/redis-wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ex
 
 sysctl vm.overcommit_memory=1
 mkdir -p /persist/redis/data

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -2,18 +2,17 @@
 nodaemon=true
 logfile=/dev/null
 logfile_maxbytes=0
+user=root
 
 [program:nginx]
 command=/usr/sbin/nginx
 stdout_logfile=/dev/stdout
-stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 
 [program:php-fpm]
 command=/usr/local/bin/php-fpm-wrapper.sh
 stdout_logfile=/dev/stdout
-stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 
@@ -21,7 +20,6 @@ redirect_stderr=true
 process_name=%(program_name)s_%(process_num)02d
 command=/usr/local/bin/artisan queue:work
 stdout_logfile=/dev/stdout
-stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 numprocs=5
@@ -29,21 +27,17 @@ numprocs=5
 [program:postgres]
 command=/usr/local/bin/postgres-wrapper.sh
 stdout_logfile=/dev/stdout
-stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 
 [program:redis]
 command=/usr/local/bin/redis-wrapper.sh
 stdout_logfile=/dev/stdout
-stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 
 [program:nuxt-backend]
 command=/usr/local/bin/nuxt-wrapper.sh
 stdout_logfile=/dev/stdout
-stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0
 redirect_stderr=true
-

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -41,3 +41,4 @@ command=/usr/local/bin/nuxt-wrapper.sh
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 redirect_stderr=true
+user=nuxt


### PR DESCRIPTION
This fixes issue #349 where the database migrations were not being run if the environment is configured to `production`.

This also tidies up the docker logs a bit and corrects a typo in the README.md file.