### PR TITLE
disable precognition on url prefill modal

### DIFF
--- a/client/components/open/forms/OpenForm.vue
+++ b/client/components/open/forms/OpenForm.vue
@@ -163,6 +163,7 @@ export default {
     },
     defaultDataForm: {},
     adminPreview: {type: Boolean, default: false}, // If used in FormEditorPreview
+    urlPrefillPreview: {type: Boolean, default: false}, // If used in UrlFormPrefill
     darkMode: {
       type: Boolean,
       default: false
@@ -449,7 +450,7 @@ export default {
       return false
     },
     nextPage() {
-      if (this.adminPreview) {
+      if (this.adminPreview || this.urlPrefillPreview) {
         this.currentFieldGroupIndex += 1
         window.scrollTo({ top: 0, behavior: 'smooth' })
         return false

--- a/client/components/pages/forms/show/UrlFormPrefill.vue
+++ b/client/components/pages/forms/show/UrlFormPrefill.vue
@@ -78,6 +78,7 @@
             :show-hidden="true"
             :form="form"
             :fields="form.properties"
+            :url-prefill-preview="true"
             @submit="generateUrl"
           >
             <template #submit-btn="{ submitForm }">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property for URL pre-filling preview to enhance user interaction.
	- Users can now see a preview of the generated URL during form submission.
- **Improvements**
	- Enhanced control flow for form navigation based on new pre-filling logic, resulting in smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->