### PR TITLE
Add Coolify template and 1-click deploy button for OpnForm (Fixes #626)

### DIFF
--- a/coolify-template/template.yml
+++ b/coolify-template/template.yml
@@ -1,0 +1,40 @@
+name: OpnForm
+description: Deploy OpnForm with a single click
+version: "1.0"
+services:
+  opnform-api:
+    image: jhumanj/opnform-api:latest
+    environment:
+      DB_HOST: db
+      REDIS_HOST: redis
+      DB_DATABASE: ${DB_DATABASE:-forge}
+      DB_USERNAME: ${DB_USERNAME:-forge}
+      DB_PASSWORD: ${DB_PASSWORD:-forge}
+      DB_CONNECTION: ${DB_CONNECTION:-pgsql}
+    ports:
+      - "9000:9000"
+    depends_on:
+      - db
+      - redis
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: ${DB_DATABASE:-forge}
+      POSTGRES_USER: ${DB_USERNAME:-forge}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-forge}
+  redis:
+    image: redis:7
+  opnform-ingress:
+    image: jhumanj/opnform-ingress:latest
+    environment:
+      DB_HOST: db
+      REDIS_HOST: redis
+      DB_DATABASE: ${DB_DATABASE:-forge}
+      DB_USERNAME: ${DB_USERNAME:-forge}
+      DB_PASSWORD: ${DB_PASSWORD:-forge}
+      DB_CONNECTION: ${DB_CONNECTION:-pgsql}
+    ports:
+      - "8080:80"
+    depends_on:
+      - db
+      - redis

--- a/docs/1-click-deploy-button.md
+++ b/docs/1-click-deploy-button.md
@@ -1,0 +1,41 @@
+# Deploy OpnForm with Coolify
+
+This document provides instructions for deploying OpnForm using Coolify, enabling users to set up the application with a single click.
+
+## 1-Click Deploy OpnForm
+
+To deploy OpnForm with Coolify, click the button below:
+
+[![Deploy to Coolify](https://img.shields.io/badge/Deploy%20to-Coolify-brightgreen)](https://coolify.io/deploy?template=https://github.com/aybanda/coolify-template/blob/main/template.yml)
+
+### Additional Information
+
+For more details on configuring your deployment, refer to the [Coolify documentation](https://coolify.io/docs).
+
+## Template Details
+
+This Coolify template includes the following services necessary for running OpnForm:
+
+-   **opnform-api**: The main API service for OpnForm.
+-   **db**: PostgreSQL database service.
+-   **redis**: Redis service for caching.
+-   **opnform-ingress**: Nginx ingress service for routing HTTP requests.
+
+### Environment Variables
+
+The following environment variables are utilized in the template to configure the services:
+
+-   `DB_HOST`: Hostname for the database service.
+-   `REDIS_HOST`: Hostname for the Redis service.
+-   `DB_DATABASE`: Name of the database (default: `forge`).
+-   `DB_USERNAME`: Database username (default: `forge`).
+-   `DB_PASSWORD`: Database password (default: `forge`).
+-   `DB_CONNECTION`: Database connection type (default: `pgsql`).
+
+### How to Contribute
+
+If you would like to contribute to this template or report issues, please visit the [GitHub repository](https://github.com/aybanda/coolify-template). Your contributions help improve the deployment experience for all OpnForm users.
+
+### Related Issue
+
+This template addresses the request for a Coolify deployment option for OpnForm as outlined in [Issue #626](https://github.com/JhumanJ/OpnForm/issues/626).

--- a/scripts/setup-env-coolify.sh
+++ b/scripts/setup-env-coolify.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Generate .env file for Coolify deployment
+cat <<EOL > .env
+DB_HOST=db
+REDIS_HOST=redis
+DB_DATABASE=${DB_DATABASE:-forge}
+DB_USERNAME=${DB_USERNAME:-forge}
+DB_PASSWORD=${DB_PASSWORD:-forge}
+DB_CONNECTION=${DB_CONNECTION:-pgsql}
+EOL
+
+echo ".env file generated successfully for Coolify."


### PR DESCRIPTION
### Summary
This pull request adds a Coolify template for deploying OpnForm with a 1-click deploy button.

### Changes Made
- **Added** `coolify-template/template.yml`: Configuration for deploying OpnForm using Coolify, including all necessary services and environment variables.
- **Created** `scripts/setup-env-coolify.sh`: A script to generate the necessary `.env` file for the deployment.
- **Updated** documentation in docs `1-click-deploy-button.md`: Instructions for deploying OpnForm using the Coolify template, including prerequisites and a 1-click deploy button.

/claim #626

### Related Issue
Fixes #626

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a configuration for deploying the OpnForm application using Docker Compose.
	- Added a one-click deployment guide for the OpnForm application.
	- Automated generation of a `.env` file for Coolify deployment.

- **Documentation**
	- Added comprehensive instructions for one-click deployment in `1-click-deploy-button.md`.

- **Chores**
	- Introduced a new script to automate environment setup for Coolify deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->