### PR TITLE
On slack,discord add support for Include hidden fields

### DIFF
--- a/api/app/Integrations/Handlers/DiscordIntegration.php
+++ b/api/app/Integrations/Handlers/DiscordIntegration.php
@@ -15,6 +15,7 @@ class DiscordIntegration extends AbstractIntegrationHandler
         return [
             'discord_webhook_url' => 'required|url|starts_with:https://discord.com/api/webhooks',
             'include_submission_data' => 'boolean',
+            'include_hidden_fields_submission_data' => ['nullable', 'boolean'],
             'link_open_form' => 'boolean',
             'link_edit_form' => 'boolean',
             'views_submissions_count' => 'boolean',
@@ -34,10 +35,14 @@ class DiscordIntegration extends AbstractIntegrationHandler
 
     protected function getWebhookData(): array
     {
+        $settings = (array) $this->integrationData ?? [];
+
         $formatter = (new FormSubmissionFormatter($this->form, $this->submissionData))->outputStringsOnly();
+        if (Arr::get($settings, 'include_hidden_fields_submission_data', false)) {
+            $formatter->showHiddenFields();
+        }
         $formattedData = $formatter->getFieldsWithValue();
 
-        $settings = (array) $this->integrationData ?? [];
         $externalLinks = [];
         if (Arr::get($settings, 'link_open_form', true)) {
             $externalLinks[] = '[**🔗 Open Form**](' . $this->form->share_url . ')';

--- a/api/app/Integrations/Handlers/SlackIntegration.php
+++ b/api/app/Integrations/Handlers/SlackIntegration.php
@@ -15,6 +15,7 @@ class SlackIntegration extends AbstractIntegrationHandler
         return [
             'slack_webhook_url' => 'required|url|starts_with:https://hooks.slack.com/',
             'include_submission_data' => 'boolean',
+            'include_hidden_fields_submission_data' => ['nullable', 'boolean'],
             'link_open_form' => 'boolean',
             'link_edit_form' => 'boolean',
             'views_submissions_count' => 'boolean',
@@ -34,10 +35,14 @@ class SlackIntegration extends AbstractIntegrationHandler
 
     protected function getWebhookData(): array
     {
+        $settings = (array) $this->integrationData ?? [];
+
         $formatter = (new FormSubmissionFormatter($this->form, $this->submissionData))->outputStringsOnly();
+        if (Arr::get($settings, 'include_hidden_fields_submission_data', false)) {
+            $formatter->showHiddenFields();
+        }
         $formattedData = $formatter->getFieldsWithValue();
 
-        $settings = (array) $this->integrationData ?? [];
         $externalLinks = [];
         if (Arr::get($settings, 'link_open_form', true)) {
             $externalLinks[] = '*<' . $this->form->share_url . '|🔗 Open Form>*';

--- a/client/components/open/integrations/components/NotificationsMessageActions.vue
+++ b/client/components/open/integrations/components/NotificationsMessageActions.vue
@@ -16,6 +16,14 @@
       help="With form submission answers"
     />
     <toggle-switch-input
+      v-if="compVal.include_submission_data"
+      v-model="compVal.include_hidden_fields_submission_data"
+      name="include_hidden_fields_submission_data"
+      class="mt-4"
+      label="Include hidden fields"
+      help="If enabled then hidden fields will be included in the notification message"
+    />
+    <toggle-switch-input
       v-model="compVal.link_open_form"
       name="link_open_form"
       class="mt-4"
@@ -85,6 +93,7 @@ export default {
     [
       "message",
       "include_submission_data",
+      'include_hidden_fields_submission_data',
       "link_open_form",
       "link_edit_form",
       "views_submissions_count",
@@ -93,6 +102,8 @@ export default {
       if (this.compVal[keyname] === undefined) {
         if (keyname === 'message') {
           this.compVal[keyname] = 'New form submission'
+        } else if (['include_hidden_fields_submission_data'].includes(keyname)) {
+          this.compVal[keyname] = false
         } else {
           this.compVal[keyname] = true
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a toggle switch for including hidden fields in notification messages.
	- Enhanced webhook data handling for both Discord and Slack integrations to optionally include hidden fields based on user settings.

- **Bug Fixes**
	- Updated initialization logic to ensure new properties are set to default values if undefined.

- **Documentation**
	- Updated validation rules for webhook submissions to include a new option for hidden fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->