### PR TITLE
Add build context to compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   api: &api
     image: jhumanj/opnform-api:latest
     build:
+      context: .
       dockerfile: docker/Dockerfile.api
     environment: &api-environment  # Add this anchor
       DB_HOST: db
@@ -21,6 +22,7 @@ services:
   api-worker:
     image: jhumanj/opnform-api:latest
     build:
+      context: .
       dockerfile: docker/Dockerfile.api
     command: php artisan queue:work
     environment:
@@ -34,6 +36,7 @@ services:
   ui:
     image: jhumanj/opnform-client:latest
     build:
+      context: .
       dockerfile: docker/Dockerfile.client
     env_file: 
     - ./client/.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@
 services:
   api: &api
     image: jhumanj/opnform-api:latest
+    build:
+      dockerfile: docker/Dockerfile.api
     environment: &api-environment  # Add this anchor
       DB_HOST: db
       REDIS_HOST: redis
@@ -18,6 +20,8 @@ services:
 
   api-worker:
     image: jhumanj/opnform-api:latest
+    build:
+      dockerfile: docker/Dockerfile.api
     command: php artisan queue:work
     environment:
       <<: *api-environment
@@ -29,6 +33,8 @@ services:
 
   ui:
     image: jhumanj/opnform-client:latest
+    build:
+      dockerfile: docker/Dockerfile.client
     env_file: 
     - ./client/.env
 

--- a/docs/deployment/docker.mdx
+++ b/docs/deployment/docker.mdx
@@ -67,7 +67,25 @@ We recommend using these official images for your OpnForm deployment.
 
 ## Building Your Own Docker Images
 
-If you prefer to build your own Docker images, you can do so using the provided Dockerfiles in the repository:
+By default, OpnForm uses pre-built images from Docker Hub. However, if you want to build the images yourself (for development or customization), you have two options:
+
+### Option 1: Using Docker Compose (Recommended)
+
+The simplest way to build the images is using Docker Compose:
+
+```bash
+docker compose build
+```
+
+This will build all the necessary images. You can then start the application as usual:
+
+```bash
+docker compose up -d
+```
+
+### Option 2: Building Images Manually
+
+You can also build the images manually using the provided Dockerfiles:
 
 1. Build the API image:
    ```bash
@@ -78,6 +96,8 @@ If you prefer to build your own Docker images, you can do so using the provided 
    ```bash
    docker build -t opnform-ui:local -f docker/Dockerfile.client .
    ```
+
+If you build the images manually, make sure to update your docker-compose.override.yml to use these local images (see below).
 
 ### Overriding Docker Compose Configuration
 


### PR DESCRIPTION
This makes it possible to build the stack (api, client) with `docker compose build` before running `docker compose up -d` without having to use override or manual build command lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Deployment**
	- Updated Docker Compose configuration to specify custom build processes for API, API worker, and UI services.
	- Added build specifications for services using specific Dockerfiles.
	- Maintained existing environment configurations.
- **Documentation**
	- Expanded deployment documentation for Docker, clarifying options for building images.
	- Provided detailed instructions for using Docker Compose and manual build processes. 
	- Added notes on updating the `docker-compose.override.yml` file for manual builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->