### PR TITLE
Update nginx.conf

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,6 +1,6 @@
-map $original_uri $api_uri {
+map $request_uri $api_uri {
     ~^/api(/.*$) $1;
-    default $original_uri;
+    default $request_uri;
 }
 
 server {


### PR DESCRIPTION
Changed undefined variable original_uri to request_uri which should use the original request uri. (nginx container won't start otherwise -- it exits with exit code 1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
	- Updated Nginx configuration to use `$request_uri` instead of `$original_uri` for API routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->