### PR TITLE
when duplicate form remove removed_properties

### DIFF
--- a/api/app/Http/Controllers/Forms/FormController.php
+++ b/api/app/Http/Controllers/Forms/FormController.php
@@ -186,6 +186,7 @@ class FormController extends Controller
         // Create copy
         $formCopy = $form->replicate();
         $formCopy->title = 'Copy of ' . $formCopy->title;
+        $formCopy->removed_properties = null;
         $formCopy->save();
 
         return $this->success([

--- a/api/app/Http/Controllers/Forms/FormController.php
+++ b/api/app/Http/Controllers/Forms/FormController.php
@@ -186,7 +186,7 @@ class FormController extends Controller
         // Create copy
         $formCopy = $form->replicate();
         $formCopy->title = 'Copy of ' . $formCopy->title;
-        $formCopy->removed_properties = null;
+        $formCopy->removed_properties = [];
         $formCopy->save();
 
         return $this->success([


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the form duplication process to reset previously removed properties, ensuring duplicated forms start with a clean slate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->