### PR TITLE
Replace env() usage within app

### DIFF
--- a/api/app/Models/Forms/Form.php
+++ b/api/app/Models/Forms/Form.php
@@ -179,7 +179,7 @@ class Form extends Model implements CachableAttributes
     public function getViewsCountAttribute()
     {
         return $this->remember('views_count', 15 * 60, function (): int {
-            if (env('DB_CONNECTION') == 'mysql') {
+            if (config('database.default') === 'mysql') {
                 return (int) ($this->views()->count() +
                     $this->statistics()->sum(DB::raw("json_extract(data, '$.views')")));
             }

--- a/api/app/Service/Forms/FormLogicConditionChecker.php
+++ b/api/app/Service/Forms/FormLogicConditionChecker.php
@@ -321,7 +321,7 @@ class FormLogicConditionChecker
             ->where(function ($query) use ($condition, $fieldValue) {
                 $fieldId = $condition['property_meta']['id'];
 
-                if (env('DB_CONNECTION') == 'mysql') {
+                if (config('database.default') === 'mysql') {
                     // For scalar values
                     $query->where(function ($q) use ($fieldId, $fieldValue) {
                         $q->whereRaw("JSON_UNQUOTE(JSON_EXTRACT(data, '$.\"$fieldId\"')) = ?", [$fieldValue]);


### PR DESCRIPTION
env() will always return the default value when used outside of config files if the config has been cached

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the application’s handling of its database configuration, ensuring more consistent behavior across environments during form processing and statistics tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->