### PR TITLE
Remove the empty placeholder for typesWithoutPlaceholder

### DIFF
--- a/client/components/open/forms/fields/components/FieldOptions.vue
+++ b/client/components/open/forms/fields/components/FieldOptions.vue
@@ -635,7 +635,7 @@ export default {
   },
   data() {
     return {
-      typesWithoutPlaceholder: ['date', 'checkbox', 'files', 'payment'],
+      typesWithoutPlaceholder: ['date', 'checkbox', 'files', 'payment', 'matrix', 'signature', 'barcode', 'scale', 'slider', 'rating'],
       editorToolbarCustom: [
         ['bold', 'italic', 'underline', 'link']
       ],


### PR DESCRIPTION
- Expanded the `typesWithoutPlaceholder` array in `FieldOptions.vue` to include new input types: 'matrix', 'signature', 'barcode', 'scale', 'slider', and 'rating'. This enhancement allows for broader form field options, improving the flexibility and usability of the form component.

These changes aim to enhance the form capabilities by accommodating a wider range of input types, thereby enriching the user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved field configuration by hiding the placeholder input for additional field types that do not support placeholders, including matrix, signature, barcode, scale, slider, and rating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->