### PR TITLE
ESC-590 - Fix UUID and Auto Increment ID Generation Logic in StoreFormSubmissio…

### DIFF
--- a/api/app/Jobs/Form/StoreFormSubmissionJob.php
+++ b/api/app/Jobs/Form/StoreFormSubmissionJob.php
@@ -179,9 +179,9 @@ class StoreFormSubmissionJob implements ShouldQueue
                 }
             } else {
                 // Standard field processing (text, ID generation, etc.)
-                if ($field['type'] == 'text' && isset($field['generates_uuid']) && $field['generates_uuid']) {
+                if (!$answerValue && $field['type'] == 'text' && isset($field['generates_uuid']) && $field['generates_uuid']) {
                     $finalData[$field['id']] = ($this->form->is_pro) ? Str::uuid()->toString() : 'Please upgrade your OpenForm subscription to use our ID generation features';
-                } elseif ($field['type'] == 'text' && isset($field['generates_auto_increment_id']) && $field['generates_auto_increment_id']) {
+                } elseif (!$answerValue && $field['type'] == 'text' && isset($field['generates_auto_increment_id']) && $field['generates_auto_increment_id']) {
                     $finalData[$field['id']] = ($this->form->is_pro) ? (string) ($this->form->submissions_count + 1) : 'Please upgrade your OpenForm subscription to use our ID generation features';
                 } else {
                     $finalData[$field['id']] = $answerValue;

--- a/api/app/Jobs/Form/StoreFormSubmissionJob.php
+++ b/api/app/Jobs/Form/StoreFormSubmissionJob.php
@@ -179,9 +179,9 @@ class StoreFormSubmissionJob implements ShouldQueue
                 }
             } else {
                 // Standard field processing (text, ID generation, etc.)
-                if (!$answerValue && $field['type'] == 'text' && isset($field['generates_uuid']) && $field['generates_uuid']) {
+                if ((!$answerValue || !Str::isUuid($answerValue)) && $field['type'] == 'text' && isset($field['generates_uuid']) && $field['generates_uuid']) {
                     $finalData[$field['id']] = ($this->form->is_pro) ? Str::uuid()->toString() : 'Please upgrade your OpenForm subscription to use our ID generation features';
-                } elseif (!$answerValue && $field['type'] == 'text' && isset($field['generates_auto_increment_id']) && $field['generates_auto_increment_id']) {
+                } elseif ((!$answerValue || !is_int($answerValue)) && $field['type'] == 'text' && isset($field['generates_auto_increment_id']) && $field['generates_auto_increment_id']) {
                     $finalData[$field['id']] = ($this->form->is_pro) ? (string) ($this->form->submissions_count + 1) : 'Please upgrade your OpenForm subscription to use our ID generation features';
                 } else {
                     $finalData[$field['id']] = $answerValue;

--- a/api/tests/Feature/Forms/FormUpdateTest.php
+++ b/api/tests/Feature/Forms/FormUpdateTest.php
@@ -1,6 +1,6 @@
 <?php
 
-
+use Illuminate\Support\Str;
 
 it('can update form with existing record', function () {
     $user = $this->actingAsProUser();
@@ -37,5 +37,58 @@ it('can update form with existing record', function () {
         $response = $this->getJson(route('forms.fetchSubmission', [$form->slug, $submissionId]))
             ->assertSuccessful();
         expect($response->json('data.' . $nameProperty['id']))->toBe('Testing Updated');
+    }
+});
+
+it('can update form with existing record but generates_uuid field is not update', function () {
+    $user = $this->actingAsProUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace, [
+        'editable_submissions' => true,
+        'properties' => [
+            [
+                'id' => 'uuid_field',
+                'type' => 'text',
+                'generates_uuid' => true,
+                'name' => 'UUID Field'
+            ],
+            [
+                'id' => 'name',
+                'type' => 'text',
+                'name' => 'Name'
+            ]
+        ]
+    ]);
+
+    $response = $this->postJson(route('forms.answer', $form->slug), ['name' => 'Testing', 'uuid_field' => null])
+        ->assertSuccessful()
+        ->assertJson([
+            'type' => 'success',
+            'message' => 'Form submission saved.',
+        ]);
+    $submissionId = $response->json('submission_id');
+    expect($submissionId)->toBeString();
+    $response = $this->getJson(route('forms.fetchSubmission', [$form->slug, $submissionId]))
+        ->assertSuccessful();
+    $uuid = $response->json('data.uuid_field');
+    expect(Str::isUuid($uuid))->toBeTrue();
+
+    if ($submissionId) {
+        $formData = $this->generateFormSubmissionData($form, ['submission_id' => $submissionId, 'name' => 'Testing Updated', 'uuid_field' => $uuid]);
+        $response = $this->postJson(route('forms.answer', $form->slug), $formData)
+            ->assertSuccessful()
+            ->assertJson([
+                'type' => 'success',
+                'message' => 'Form submission saved.',
+            ]);
+        $submissionId2 = $response->json('submission_id');
+        expect($submissionId2)->toBeString();
+        expect($submissionId2)->toBe($submissionId);
+
+        $response = $this->getJson(route('forms.fetchSubmission', [$form->slug, $submissionId]))
+            ->assertSuccessful();
+        expect($response->json('data.name'))->toBe('Testing Updated');
+        $uuid2 = $response->json('data.uuid_field');
+        expect($uuid2)->toBe($uuid);
     }
 });


### PR DESCRIPTION
…nJob

- Updated the conditions for generating UUID and auto-increment IDs in the `StoreFormSubmissionJob` to ensure they only trigger when the answer value is not provided. This change enhances the logic for handling form submissions, particularly for users with non-pro subscriptions, by preventing unnecessary ID generation when an answer is already present.

These modifications aim to improve the accuracy of form submissions and ensure proper handling of ID generation based on user subscription status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved form handling so that UUIDs or auto-increment IDs for text fields are only generated when no answer is provided, ensuring user input is preserved if present.
- **Tests**
  - Added tests to confirm UUID fields remain unchanged during form submission updates, preserving data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->