### PR TITLE
Enhance Quill mention and color support

### DIFF
--- a/client/lib/colors.js
+++ b/client/lib/colors.js
@@ -110,5 +110,21 @@ const tailwindcssPaletteGenerator = (options) => {
   return palette
 }
 
+// Notion default color palette (text colors)
+const notionColors = [
+  '#37352F', // default (almost black)
+  '#9B9A97', // gray
+  '#64473A', // brown
+  '#D9730D', // orange
+  '#DFAB01', // yellow
+  '#0F7B6C', // green
+  '#0B6E99', // blue
+  '#6940A5', // purple
+  '#AD1A72', // pink
+  '#E03E3E', // red
+  '#FFFFFF', // white
+  '#000000'  // black
+]
+
 // Exporting the functions
-export { generateColor, tailwindcssPaletteGenerator }
+export { generateColor, tailwindcssPaletteGenerator, notionColors }

--- a/client/lib/quill/quillMentionExtension.js
+++ b/client/lib/quill/quillMentionExtension.js
@@ -27,9 +27,9 @@ export default function registerMentionExtension(QuillInstance) {
       // Match any span with a 'mention' attribute
       static matches(domNode) {
         return (
-          domNode instanceof HTMLElement && 
-          domNode.tagName === this.tagName && 
-          domNode.hasAttribute('mention')
+          domNode instanceof HTMLElement &&
+          domNode.tagName === this.tagName &&
+          domNode.getAttribute('mention') === 'true'
         )
       }
 
@@ -78,25 +78,6 @@ export default function registerMentionExtension(QuillInstance) {
     QuillInstance.register('formats/mention', MentionBlot)
   }
 
-  // Add clipboard matcher for handling mentions in pasted/loaded HTML
-  if (QuillInstance.clipboard && typeof QuillInstance.clipboard.addMatcher === 'function') {
-    QuillInstance.clipboard.addMatcher('span[mention]', (node, delta) => {
-      if (node.hasAttribute('mention')) {
-        const mentionData = {
-          field: {
-            id: node.getAttribute('mention-field-id') || '',
-            name: node.getAttribute('mention-field-name') || ''
-          },
-          fallback: node.getAttribute('mention-fallback') || ''
-        }
-        
-        return new Delta().insert({ mention: mentionData })
-      }
-      
-      return delta
-    })
-  }
-
   /**
    * MentionModule - Handles mention UI integration with Quill
    */
@@ -114,6 +95,7 @@ export default function registerMentionExtension(QuillInstance) {
         })
         
         this.setupMentions()
+        this.addClipboardMatcher()
       }
       
       setupMentions() {
@@ -164,6 +146,33 @@ export default function registerMentionExtension(QuillInstance) {
           this.quill.focus()
           this.quill.setSelection(index + 1, 0, QuillInstance.sources.SILENT)
         })
+      }
+
+      /**
+       * Adds a clipboard matcher that ensures styled spans are not
+       * incorrectly interpreted as mentions when pasting HTML.
+       */
+      addClipboardMatcher() {
+        if (this.quill.clipboard && typeof this.quill.clipboard.addMatcher === 'function') {
+          this.quill.clipboard.addMatcher('span', (node, delta) => {
+            const isRealMention = node.getAttribute && node.getAttribute('mention') === 'true'
+            const isInterpretedAsMention = Array.isArray(delta.ops) && delta.ops.some(op => op.insert && typeof op.insert.mention === 'object')
+
+            // Correctly recognised mention – leave as is
+            if (isRealMention) {
+              return delta
+            }
+
+            // Span was mis-identified as a mention – revert to simple text keeping its attributes
+            if (isInterpretedAsMention) {
+              const attributes = (delta.ops[0] && delta.ops[0].attributes) || {}
+              return new Delta().insert(node.innerText, attributes)
+            }
+
+            // Regular span – keep default behaviour
+            return delta
+          })
+        }
       }
     }
     

--- a/client/lib/quill/quillPatches.js
+++ b/client/lib/quill/quillPatches.js
@@ -1,7 +1,13 @@
 import Quill from 'quill'
+import { notionColors } from '../colors.js'
 
 // Self-executing function to patch Quill's prototype
 ;(function installQuillFixes() {
+  // Whitelist Notion colors
+  const ColorAttributor = Quill.import('attributors/style/color')
+  ColorAttributor.whitelist = notionColors
+  Quill.register(ColorAttributor, true)
+
   // Store the original method
   const originalGetSemanticHTML = Quill.prototype.getSemanticHTML
 


### PR DESCRIPTION
Quill editor functionality was enhanced with updates to mention handling and color support.

*   In `client/lib/quill/quillMentionExtension.js`:
    *   The `MentionBlot.value` static method was updated to strictly check `domNode.getAttribute('mention') === 'true'`, preventing misidentification of styled spans as mentions.
    *   The old global clipboard matcher was removed.
    *   A new `addClipboardMatcher()` method was added to the `MentionModule` and invoked in its constructor. This new matcher differentiates real mentions from misidentified styled spans during paste operations, ensuring correct formatting.

*   In `client/lib/quill/quillPatches.js`:
    *   `notionColors` were imported from `../colors.js`.
    *   Quill's `ColorAttributor` whitelist was set to `notionColors` and then registered, enabling custom Notion-style colors in the editor.

*   In `client/lib/colors.js`:
    *   The `notionColors` array was added and exported to provide the specific color palette.

These changes improve mention accuracy and expand color customization options.