### PR TITLE
Custom domain restriction

### DIFF
--- a/client/components/pages/settings/WorkSpaceCustomDomains.vue
+++ b/client/components/pages/settings/WorkSpaceCustomDomains.vue
@@ -111,9 +111,7 @@ const saveChanges = () => {
       useAlert().success("Custom domains saved.")
     })
     .catch((error) => {
-      useAlert().error(
-        "Failed to update custom domains: " + error.response.data.message,
-      )
+      useAlert().error(error.response._data.message ?? 'Failed to update custom domains')
     })
     .finally(() => {
       customDomainsLoading.value = false


### PR DESCRIPTION
Implement Custom Domain Validation and Testing for Workspaces
- Enhanced the `CustomDomainRequest` to validate custom domains by checking format and ensuring they are not already in use by other workspaces. Improved error handling for invalid domains and domain count limits.
- Added comprehensive tests in `WorkspaceTest` to verify the functionality of saving custom domains, including format validation and prevention of duplicate domains across workspaces.
- Updated error messaging in the front-end component to provide clearer feedback on domain validation issues.

These changes aim to improve the reliability of custom domain management within workspaces and enhance user experience through better validation and error handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when updating custom domains, ensuring users see more accurate error messages if the update fails.
  - Enhanced validation to prevent assigning a custom domain to multiple workspaces, with clear error messages for conflicts and invalid formats.

- **Tests**
  - Added comprehensive tests to verify custom domain management, including validation for invalid domains and prevention of duplicate assignments across workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->