### PR TITLE
Update docker compose ui healthcheck to use curl

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     env_file:
       - ./client/.env
     healthcheck:
-      test: ["CMD-SHELL", "wget --spider -q http://localhost:3000/login || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://localhost:3000/login || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
Current docker compose file uses `wget` as a healtcheck inside the `ui` service, which is an `opnform-client` image that is based on Node Alpine image.

Using `wget` from Alpine in Docker is problematic: it leaves zombie processes (in my case, it was leaving defunct `ssl_client` processes, probably because the client was trying to redirect to final HTTPS URL).

There are two possible approaches. Using `init: true` would cause the zombies to be reaped, mut might have other side effects.

The simplest solution is to switch the health check to an equivalent `curl -f` call, since Node image has it installed; this does not leave zombies.

This approach was gleaned from this (unrelated) bug report where a similar problem was encountered: https://github.com/caddyserver/caddy-docker/issues/276#issuecomment-2850487492

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the healthcheck command for the UI service in Docker Compose to use `curl` instead of `wget`. This does not affect application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->