### PR TITLE
ESC-656 Fix Custom SEO

### DIFF
--- a/client/components/open/forms/components/form-components/FormCustomSeo.vue
+++ b/client/components/open/forms/components/form-components/FormCustomSeo.vue
@@ -122,12 +122,15 @@ const customDomainOptions = computed(() => {
 
 onMounted(() => {
   if (!form.value.seo_meta || Array.isArray(form.value.seo_meta))
-    form.value.seo_meta = {};
+    form.value.seo_meta = {}
 
-  ['page_title', 'page_description', 'page_thumbnail', 'page_favicon'].forEach((keyname) => {
-    if (form.value.seo_meta[keyname] === undefined)
-      form.value.seo_meta[keyname] = null
-  })
+  form.value.seo_meta = {
+    ...form.value.seo_meta,
+    page_title: form.value.seo_meta.page_title === undefined ? null : form.value.seo_meta.page_title,
+    page_description: form.value.seo_meta.page_description === undefined ? null : form.value.seo_meta.page_description,
+    page_thumbnail: form.value.seo_meta.page_thumbnail === undefined ? null : form.value.seo_meta.page_thumbnail,
+    page_favicon: form.value.seo_meta.page_favicon === undefined ? null : form.value.seo_meta.page_favicon,
+  }
 
   if (form.value.custom_domain && workspace.value?.custom_domains && !workspace.value.custom_domains.find((item) => { return item === form.value.custom_domain })) {
     form.value.custom_domain = null


### PR DESCRIPTION
Refactor FormCustomSeo component to initialize SEO metadata
- Updated the `FormCustomSeo.vue` component to initialize the `seo_meta` object more efficiently by using object spread syntax. This change ensures that all necessary SEO fields (`page_title`, `page_description`, `page_thumbnail`, `page_favicon`) are set to `null` if they are undefined, improving data integrity and preventing potential errors during form submission.

These changes aim to enhance the handling of SEO metadata within the form, ensuring a more robust and user-friendly experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the initialization logic for SEO metadata fields to ensure more reliable default values. No changes to visible features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->