### PR TITLE
Add link_edit_submission field to EmailIntegration and update email n…

### DIFF
--- a/api/app/Integrations/Handlers/EmailIntegration.php
+++ b/api/app/Integrations/Handlers/EmailIntegration.php
@@ -27,6 +27,7 @@ class EmailIntegration extends AbstractIntegrationHandler
             'include_submission_data' => 'boolean',
             'include_hidden_fields_submission_data' => ['nullable', 'boolean'],
             'reply_to' => 'nullable',
+            'link_edit_submission' => ['nullable', 'boolean']
         ];
 
         if ($form->is_pro || config('app.self_hosted')) {

--- a/api/resources/views/mail/form/email-notification.blade.php
+++ b/api/resources/views/mail/form/email-notification.blade.php
@@ -2,7 +2,7 @@
 
 {!! $emailContent !!}
 
-@if($form->editable_submissions)
+@if(($integrationData->link_edit_submission ?? false) && $form->editable_submissions)
 @component('mail::button', ['url' => $form->share_url.'?submission_id='.$submission_id])
 {{($form->editable_submissions_button_text ?? 'Edit submission')}}
 @endcomponent
@@ -12,8 +12,8 @@
 @foreach($fields as $field)
 @if(isset($field['value']))
 <p style="white-space: pre-wrap; border-top: 1px solid #9ca3af;">
-<b>{{$field['name']}}</b>
-{!! is_array($field['value'])?implode(',',$field['value']):$field['value']!!}
+    <b>{{$field['name']}}</b>
+    {!! is_array($field['value'])?implode(',',$field['value']):$field['value']!!}
 </p>
 @endif
 @endforeach

--- a/api/tests/Feature/Forms/EmailNotificationTest.php
+++ b/api/tests/Feature/Forms/EmailNotificationTest.php
@@ -325,3 +325,65 @@ it('send email with hidden field as mention to send email', function () {
         }
     );
 });
+
+it('send email with the edit submission link', function () {
+    $user = $this->actingAsProUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace, [
+        'editable_submissions' => true,
+        'editable_submissions_button_text' => 'Edit submission'
+    ]);
+    $integrationData = $this->createFormIntegration('email', $form->id, [
+        'send_to' => $user->email,
+        'sender_name' => 'OpnForm',
+        'subject' => 'New form submission',
+        'email_content' => 'Hello there 👋 <br>Test body',
+        'include_submission_data' => true,
+        'include_hidden_fields_submission_data' => false,
+        'reply_to' => 'reply@example.com',
+        'link_edit_submission' => true,
+    ]);
+
+    $formData = $this->generateFormSubmissionData($form);
+
+    $event = new \App\Events\Forms\FormSubmitted($form, $formData);
+    $mailable = new FormEmailNotification($event, $integrationData, 'mail');
+    $notifiable = new AnonymousNotifiable();
+    $notifiable->route('mail', $user->email);
+    $renderedMail = $mailable->toMail($notifiable);
+    expect($renderedMail->subject)->toBe('New form submission');
+    expect($renderedMail->replyTo[0][0])->toBe('reply@example.com');
+    expect(trim($renderedMail->render()))->toContain('Test body');
+    expect(trim($renderedMail->render()))->toContain('Edit submission');
+});
+
+it('send email without the edit submission link', function () {
+    $user = $this->actingAsProUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace, [
+        'editable_submissions' => true,
+        'editable_submissions_button_text' => 'Edit submission'
+    ]);
+    $integrationData = $this->createFormIntegration('email', $form->id, [
+        'send_to' => $user->email,
+        'sender_name' => 'OpnForm',
+        'subject' => 'New form submission',
+        'email_content' => 'Hello there 👋 <br>Test body',
+        'include_submission_data' => true,
+        'include_hidden_fields_submission_data' => false,
+        'reply_to' => 'reply@example.com',
+        'link_edit_submission' => false,
+    ]);
+
+    $formData = $this->generateFormSubmissionData($form);
+
+    $event = new \App\Events\Forms\FormSubmitted($form, $formData);
+    $mailable = new FormEmailNotification($event, $integrationData, 'mail');
+    $notifiable = new AnonymousNotifiable();
+    $notifiable->route('mail', $user->email);
+    $renderedMail = $mailable->toMail($notifiable);
+    expect($renderedMail->subject)->toBe('New form submission');
+    expect($renderedMail->replyTo[0][0])->toBe('reply@example.com');
+    expect(trim($renderedMail->render()))->toContain('Test body');
+    expect(trim($renderedMail->render()))->not->toContain('Edit submission');
+});

--- a/client/components/open/integrations/EmailIntegration.vue
+++ b/client/components/open/integrations/EmailIntegration.vue
@@ -83,9 +83,16 @@
       label="Include hidden fields"
       help="If enabled the email will contain hidden fields"
     />
+    <toggle-switch-input
+      :form="integrationData"
+      name="settings.link_edit_submission"
+      class="mt-4"
+      label="Edit Submission Link"
+    />
     <MentionInput
       :form="integrationData"
       :mentions="form.properties"
+      class="mt-4"
       name="settings.reply_to"
       label="Reply To"
       help="If empty, Reply-to will be your own email."

--- a/client/components/open/integrations/EmailIntegration.vue
+++ b/client/components/open/integrations/EmailIntegration.vue
@@ -84,6 +84,7 @@
       help="If enabled the email will contain hidden fields"
     />
     <toggle-switch-input
+      v-if="form.editable_submissions"
       :form="integrationData"
       name="settings.link_edit_submission"
       class="mt-4"

--- a/client/components/open/integrations/components/NotificationsMessageActions.vue
+++ b/client/components/open/integrations/components/NotificationsMessageActions.vue
@@ -45,6 +45,7 @@
       help="Form views and submissions count"
     />
     <toggle-switch-input
+      v-if="form.editable_submissions"
       v-model="compVal.link_edit_submission"
       name="link_edit_submission"
       class="mt-4"


### PR DESCRIPTION
…otification logic

- Introduced a new field `link_edit_submission` in the `EmailIntegration` class to allow conditional inclusion of an edit submission link in email notifications.
- Updated the email notification Blade template to check for the new field when determining if the edit submission button should be displayed.
- Added a toggle switch input for the `link_edit_submission` setting in the `EmailIntegration.vue` component, enhancing user control over email content.

These changes aim to improve the flexibility of email notifications by allowing users to include an edit link for submissions when desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Edit Submission Link” toggle in Email Integration settings to include an edit link in notification emails.
  * Edit button in email notifications now appears only when both the form allows edits and the integration toggle is enabled.

* **Style**
  * Improved spacing in Email Integration settings for better readability.
  * Minor whitespace adjustments in email notification content for cleaner presentation.

* **Tests**
  * Added tests verifying presence/absence of the edit link in rendered notification emails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->