### PR TITLE
Refactor FormSubmissionFormatter to enhance CSV output handling

### DIFF
--- a/api/app/Service/Forms/FormSubmissionFormatter.php
+++ b/api/app/Service/Forms/FormSubmissionFormatter.php
@@ -152,7 +152,7 @@ class FormSubmissionFormatter
             } elseif ($field['type'] == 'multi_select') {
                 $val = $data[$field['id']];
                 if ($this->outputStringsOnly && is_array($val)) {
-                    $returnArray[$field['name']] = implode(', ', $val);
+                    $returnArray[$field['name']] = $this->implodeCsvSafe($val);
                 } else {
                     $returnArray[$field['name']] = $val;
                 }
@@ -180,7 +180,7 @@ class FormSubmissionFormatter
                 }
             } else {
                 if (is_array($data[$field['id']]) && $this->outputStringsOnly) {
-                    $data[$field['id']] = implode(', ', $data[$field['id']]);
+                    $data[$field['id']] = $this->implodeCsvSafe($data[$field['id']]);
                 }
                 $returnArray[$field['name']] = $data[$field['id']];
             }
@@ -230,7 +230,7 @@ class FormSubmissionFormatter
             } elseif ($field['type'] == 'multi_select') {
                 $val = $data[$field['id']];
                 if ($this->outputStringsOnly) {
-                    $field['value'] = implode(', ', $val);
+                    $field['value'] = $this->implodeCsvSafe($val);
                 } else {
                     $field['value'] = $val;
                 }
@@ -269,7 +269,7 @@ class FormSubmissionFormatter
                 }
             } else {
                 if (is_array($data[$field['id']]) && $this->outputStringsOnly) {
-                    $field['value'] = implode(', ', $data[$field['id']]);
+                    $field['value'] = $this->implodeCsvSafe($data[$field['id']]);
                 } else {
                     $field['value'] = $data[$field['id']];
                 }
@@ -304,5 +304,34 @@ class FormSubmissionFormatter
             throw $e;
             return null;
         }
+    }
+
+    /**
+     * Escape a field value for CSV format
+     * Wraps fields containing commas or quotes in double quotes
+     * Escapes internal quotes by doubling them
+     */
+    private function escapeCsvField($field)
+    {
+        // Convert to string if not already
+        $field = (string) $field;
+
+        // If field contains comma, double quote, or newline, wrap in quotes
+        if (strpos($field, ',') !== false || strpos($field, '"') !== false || strpos($field, "\n") !== false || strpos($field, "\r") !== false) {
+            // Escape any existing double quotes by doubling them
+            $field = str_replace('"', '""', $field);
+            // Wrap the entire field in double quotes
+            $field = '"' . $field . '"';
+        }
+
+        return $field;
+    }
+
+    /**
+     * Join array values with commas, properly escaping CSV fields
+     */
+    private function implodeCsvSafe(array $values): string
+    {
+        return implode(',', array_map([$this, 'escapeCsvField'], $values));
     }
 }


### PR DESCRIPTION
- Updated the `FormSubmissionFormatter` class to replace `implode` with a new `implodeCsvSafe` method for joining multi-select values, ensuring proper CSV formatting by escaping fields containing commas or quotes.
- Introduced `escapeCsvField` method to handle the escaping of individual field values for CSV output, improving data integrity when exporting form submissions.

These changes aim to enhance the reliability of CSV exports for form submissions by ensuring that special characters are correctly handled.


Fixed #864 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSV exports now correctly escape commas, quotes, and newlines in multi-select and other array-based fields, preventing broken columns in spreadsheets.
  * Improves consistency when exporting values as plain text, ensuring reliable CSV output across relevant fields.
* **Refactor**
  * Streamlined internal CSV formatting logic to reduce errors and improve maintainability (no user-facing changes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->