### PR TITLE
Enhance VSelect and PhoneInput components with popover width support …

### DIFF
--- a/client/components/forms/core/SelectInput.vue
+++ b/client/components/forms/core/SelectInput.vue
@@ -35,7 +35,7 @@
     >
       <template #selected="{ option }">
         <template v-if="multiple">
-          <div class="flex items-center truncate mr-6">
+          <div class="flex items-center truncate ltr-only:mr-6 rtl-only:ml-6">
             <span
               class="truncate"
               :class="ui.selected()"
@@ -50,7 +50,7 @@
             :option="option"
             :option-name="getOptionName(option)"
           >
-            <div class="flex items-center truncate mr-6">
+            <div class="flex items-center truncate ltr-only:mr-6 rtl-only:ml-6">
               <div :class="ui.selected()">
                 {{ getOptionName(option) }}
               </div>

--- a/client/components/forms/core/components/VSelect.vue
+++ b/client/components/forms/core/components/VSelect.vue
@@ -11,7 +11,7 @@
         sideOffset: 4
       }"
       :ui="{
-        content: 'w-(--reka-popper-anchor-width) bg-white dark:!bg-notion-dark-light shadow-xl z-30 overflow-auto ' + borderRadiusClass
+        content: (popoverWidth ? `w-[${popoverWidth}] ` : 'w-(--reka-popper-anchor-width) ') + 'bg-white dark:!bg-notion-dark-light shadow-xl z-30 overflow-auto ' + borderRadiusClass
       }"
     >
       <template #anchor>
@@ -239,7 +239,8 @@ export default {
     allowCreation: { type: Boolean, default: false },
     disabled: { type: Boolean, default: false },
     minSelection: { type: Number, default: null },
-    maxSelection: { type: Number, default: null }
+    maxSelection: { type: Number, default: null },
+    popoverWidth: { type: String, default: null }
   },
   emits: ['update:modelValue', 'update-options', 'focus', 'blur'],
   data () {

--- a/client/components/forms/heavy/PhoneInput.vue
+++ b/client/components/forms/heavy/PhoneInput.vue
@@ -40,21 +40,21 @@
               :country="props.option.code"
             />
             <span class="truncate">{{ props.option.name }}</span>
-            <span class="text-gray-500">{{ props.option.dial_code }}</span>
+            <span class="text-gray-500 whitespace-nowrap">{{ props.option.dial_code && props.option.dial_code.startsWith('+') ? props.option.dial_code : '+' + props.option.dial_code }}</span>
           </div>
         </template>
         <template #selected="props">
           <div
-            class="flex items-center gap-2 justify-center overflow-hidden"
+            class="flex items-center gap-2 w-full overflow-hidden ltr-only:pr-8 rtl-only:pl-8"
             :class="ui.selectedMaxHeight()"
           >
+            <span class="text-sm whitespace-nowrap shrink-0">{{ props.option.dial_code && props.option.dial_code.startsWith('+') ? props.option.dial_code : '+' + props.option.dial_code }}</span>
             <country-flag
               :size="countryFlagSize"
-              class="rounded-lg!"
+              class="rounded-lg! ms-auto shrink-0"
               :class="ui.flag()"
               :country="props.option.code"
             />
-            <span class="text-sm">{{ props.option.dial_code }}</span>
           </div>
         </template>
       </v-select>
@@ -192,13 +192,19 @@ export default {
         return
       }
       if (!this.compVal?.startsWith('+')) {
-        this.selectedCountryCode = this.getCountryBy(this.compVal.substring(2, 0))
+        // If the user already selected a country, don't override it with inference
+        if (!this.selectedCountryCode) {
+          this.selectedCountryCode = this.getCountryBy(this.compVal.substring(2, 0))
+        }
       }
 
       const phoneObj = parsePhoneNumber(this.compVal)
       if (phoneObj !== undefined && phoneObj) {
         if (phoneObj.country !== undefined && phoneObj.country) {
-          this.selectedCountryCode = this.getCountryBy(phoneObj.country)
+          // Respect manual selection; infer only when none is set
+          if (!this.selectedCountryCode) {
+            this.selectedCountryCode = this.getCountryBy(phoneObj.country)
+          }
         }
         this.inputVal = phoneObj.nationalNumber
       }

--- a/client/components/forms/heavy/PhoneInput.vue
+++ b/client/components/forms/heavy/PhoneInput.vue
@@ -10,11 +10,12 @@
       :id="id ? id : name"
       :name="name"
       :style="inputStyle"
-      class="flex items-stretch"
+      class="grid items-stretch w-full grid-cols-[auto_minmax(0,1fr)]"
     >
       <v-select
+        class="min-w-0"
         v-model="selectedCountryCode"
-        dropdown-class="max-w-[300px]"
+        popover-width="full"
         input-class="ltr-only:rounded-r-none rtl:rounded-l-none!"
         :data="countries"
         :disabled="disabled || countries.length===1"
@@ -38,8 +39,8 @@
               class="-mt-[9px]! rounded"
               :country="props.option.code"
             />
-            <span class="grow truncate">{{ props.option.name }}</span>
-            <span>{{ props.option.dial_code }}</span>
+            <span class="truncate">{{ props.option.name }}</span>
+            <span class="text-gray-500">{{ props.option.dial_code }}</span>
           </div>
         </template>
         <template #selected="props">
@@ -60,7 +61,7 @@
       <input
         v-model="inputVal"
         type="text"
-        class="inline-flex-grow ltr-only:border-l-0 ltr-only:!rounded-l-none rtl:border-r-0 rtl:rounded-r-none"
+        class="w-full min-w-0 ltr-only:border-l-0 ltr-only:!rounded-l-none rtl:border-r-0 rtl:rounded-r-none"
         :disabled="disabled?true:null"
         :class="ui.input()"
         :placeholder="placeholder"
@@ -190,7 +191,7 @@ export default {
 
       const phoneObj = parsePhoneNumber(this.compVal)
       if (phoneObj !== undefined && phoneObj) {
-        if (!this.selectedCountryCode && phoneObj.country !== undefined && phoneObj.country) {
+        if (phoneObj.country !== undefined && phoneObj.country) {
           this.selectedCountryCode = this.getCountryBy(phoneObj.country)
         }
         this.inputVal = phoneObj.nationalNumber

--- a/client/components/open/forms/fields/components/FieldOptions.vue
+++ b/client/components/open/forms/fields/components/FieldOptions.vue
@@ -387,11 +387,13 @@
         name="use_simple_text_input"
         label="Use simple text input"
       />
+
       <template v-if="field.type === 'phone_number' && !field.use_simple_text_input">
         <select-input
+          class="mt-3"
           v-model="field.unavailable_countries"
-          class="mt-4"
-          wrapper-class="relative"
+          popover-width="full"
+          input-class="ltr-only:rounded-r-none rtl:rounded-l-none!"
           :options="allCountries"
           :multiple="true"
           :searchable="true"
@@ -408,14 +410,14 @@
             </div>
           </template>
           <template #option="{ option, selected }">
-            <div class="flex items-center space-x-2 hover:text-white">
+            <div class="flex items-center gap-2 max-w-full">
               <country-flag
                 size="normal"
-                class="!-mt-[9px]"
+                class="-mt-[9px]! rounded"
                 :country="option.code"
               />
-              <span class="grow">{{ option.name }}</span>
-              <span>{{ option.dial_code }}</span>
+              <span class="truncate">{{ option.name }}</span>
+              <span class="text-gray-500">{{ option.dial_code }}</span>
             </div>
             <span
               v-if="selected"

--- a/client/css/app.css
+++ b/client/css/app.css
@@ -3,7 +3,8 @@
 @import "./fonts.css";
 
 @custom-variant dark (&:where(.dark, .dark *));
-@custom-variant ltr-only (&:where(:not([dir="rtl"] *)));
+@custom-variant ltr-only (&:where(:dir(ltr)));
+@custom-variant rtl-only (&:where(:dir(rtl)));
 
 /* Explicitly scan form-themes.js file */
 @source "./lib/forms/themes/form-themes.js";

--- a/client/lib/forms/themes/v-select.theme.js
+++ b/client/lib/forms/themes/v-select.theme.js
@@ -11,15 +11,15 @@ export const vSelectTheme = {
     ],
     buttonInner: [
       'flex items-center',
-      'ltr:pr-8 rtl:pl-8'
+      'ltr-only:pr-8 rtl-only:pl-8'
     ],
     placeholder: [
       'text-neutral-400 dark:text-neutral-500 w-full ltr:text-left rtl:text-right! truncate ltr:pr-3 rtl:pl-3 rtl:pr-0!'
     ],
-    chevronGradient: 'absolute inset-y-0 ltr:right-6 rtl:left-6 w-10 pointer-events-none -z-1',
+    chevronGradient: 'absolute inset-y-0 ltr-only:right-6 rtl-only:left-6 w-10 pointer-events-none -z-1',
     chevronContainer: [
-      'absolute inset-y-0 ltr:right-0 rtl:left-0 rtl:right-auto!',
-      'flex items-center ltr:pr-2 rtl:pl-2 rtl:pr-0! pointer-events-none'
+      'absolute inset-y-0 ltr-only:right-0 rtl-only:left-0 rtl-only:right-auto!',
+      'flex items-center ltr-only:pr-2 rtl-only:pl-2 rtl-only:pr-0! pointer-events-none'
     ],
     chevronIcon: 'h-5 w-5 text-neutral-500',
     clearButton: [
@@ -37,10 +37,10 @@ export const vSelectTheme = {
       'grow ltr:pl-3 ltr:pr-7 rtl:pr-3! rtl:pl-7 py-2 w-full focus:outline-hidden dark:text-white'
     ],
     searchIconContainer: [
-      'flex absolute ltr:right-0 rtl:left-0 rtl:right-auto! inset-y-0 items-center px-2 justify-center pointer-events-none'
+      'flex absolute ltr-only:right-0 rtl-only:left-0 rtl-only:right-auto! inset-y-0 items-center px-2 justify-center pointer-events-none'
     ],
     searchClearContainer: [
-      'flex absolute ltr:right-0 rtl:right-auto! rtl:left-0 inset-y-0 items-center px-2 justify-center'
+      'flex absolute ltr-only:right-0 rtl-only:right-auto! rtl-only:left-0 inset-y-0 items-center px-2 justify-center'
     ],
     searchIcon: 'h-5 w-5 text-neutral-500 dark:text-neutral-400',
     searchClearIcon: 'h-5 w-5 rtl:rotate-180 text-neutral-500 dark:text-neutral-400',


### PR DESCRIPTION
…and layout improvements

- Updated `VSelect.vue` to conditionally set the popover width based on the new `popoverWidth` prop, improving responsiveness.
- Modified `PhoneInput.vue` to adjust layout classes for better alignment and added `popover-width` attribute for consistent dropdown behavior.
- Enhanced styling in `PhoneInput.vue` to ensure proper truncation and visual clarity of country options.

These changes aim to improve the usability and visual consistency of form components, ensuring a better user experience during input selection.

Also Fixed: #877 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - VSelect supports custom dropdown widths via a new popover width option.
  - Phone input includes a fully searchable, configurable country selector.

- Style
  - Direction-aware spacing and alignment updates for select controls.
  - Unified full-width dropdowns, truncated country names, gray dial codes, and improved flag/layout styling.

- Bug Fixes
  - Country inference now respects manual selection, preventing unintended overrides.

- Refactor
  - Phone input layout converted to a grid for improved responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->