### PR TITLE
Add Serbian language support

### DIFF
--- a/api/app/Models/Forms/Form.php
+++ b/api/app/Models/Forms/Form.php
@@ -42,7 +42,7 @@ class Form extends Model implements CachableAttributes
 
     public const VISIBILITY = ['public', 'draft', 'closed'];
 
-    public const LANGUAGES = ['en', 'fr', 'hi', 'es', 'ar', 'zh', 'ja', 'bn', 'pt', 'ru', 'ur', 'pa', 'de', 'jv', 'ko', 'vi', 'te', 'mr', 'ta', 'tr', 'sk', 'cs', 'eu', 'gl', 'ca', 'sv', 'pl', 'nl'];
+    public const LANGUAGES = ['en', 'fr', 'hi', 'es', 'ar', 'zh', 'ja', 'bn', 'pt', 'ru', 'ur', 'pa', 'de', 'jv', 'ko', 'vi', 'te', 'mr', 'ta', 'tr', 'sk', 'cs', 'eu', 'gl', 'ca', 'sv', 'pl', 'nl', 'sr'];
 
     protected $fillable = [
         'workspace_id',

--- a/api/config/app.php
+++ b/api/config/app.php
@@ -147,6 +147,7 @@ return [
         'sv' => 'SV',
         'pl' => 'PL',
         'nl' => 'NL',
+        'sr' => 'SR',
     ],
 
     /*

--- a/api/resources/lang/sr/validation.php
+++ b/api/resources/lang/sr/validation.php
@@ -1,0 +1,155 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines contain the default error messages used by
+    | the validator class. Some of these rules have multiple versions such
+    | as the size rules. Feel free to tweak each of these messages here.
+    |
+    */
+
+    'accepted' => ':attribute mora biti prihvaćen.',
+    'active_url' => ':attribute nije validan URL.',
+    'after' => ':attribute mora biti datum posle :date.',
+    'after_or_equal' => ':attribute mora biti datum posle ili jednak :date.',
+    'alpha' => ':attribute može da sadrži samo slova.',
+    'alpha_dash' => ':attribute može da sadrži samo slova, brojeve, crtice i donje crte.',
+    'alpha_num' => ':attribute može da sadrži samo slova i brojeve.',
+    'array' => ':attribute mora biti niz.',
+    'before' => ':attribute mora biti datum pre :date.',
+    'before_or_equal' => ':attribute mora biti datum pre ili jednak :date.',
+    'between' => [
+        'numeric' => ':attribute mora biti između :min i :max.',
+        'file' => ':attribute mora biti između :min i :max kilobajta.',
+        'string' => ':attribute mora imati između :min i :max karaktera.',
+        'array' => ':attribute mora imati između :min i :max stavki.',
+    ],
+    'boolean' => 'Polje :attribute mora biti tačno ili netačno.',
+    'confirmed' => 'Potvrda polja :attribute se ne poklapa.',
+    'date' => ':attribute nije važeći datum.',
+    'date_equals' => ':attribute mora biti datum jednak :date.',
+    'date_format' => ':attribute ne odgovara formatu :format.',
+    'different' => ':attribute i :other moraju biti različiti.',
+    'digits' => ':attribute mora imati :digits cifara.',
+    'digits_between' => ':attribute mora imati između :min i :max cifara.',
+    'dimensions' => ':attribute ima nevažeće dimenzije slike.',
+    'distinct' => 'Polje :attribute ima duplu vrednost.',
+    'email' => ':attribute mora biti važeća email adresa.',
+    'ends_with' => ':attribute mora se završavati jednim od sledećih: :values.',
+    'exists' => 'Izabrani :attribute je nevažeći.',
+    'file' => ':attribute mora biti fajl.',
+    'filled' => 'Polje :attribute mora imati vrednost.',
+    'gt' => [
+        'numeric' => ':attribute mora biti veći od :value.',
+        'file' => ':attribute mora biti veći od :value kilobajta.',
+        'string' => ':attribute mora imati više od :value karaktera.',
+        'array' => ':attribute mora imati više od :value stavki.',
+    ],
+    'gte' => [
+        'numeric' => ':attribute mora biti veći ili jednak :value.',
+        'file' => ':attribute mora biti veći ili jednak :value kilobajta.',
+        'string' => ':attribute mora imati najmanje :value karaktera.',
+        'array' => ':attribute mora imati :value stavki ili više.',
+    ],
+    'image' => ':attribute mora biti slika.',
+    'in' => 'Izabrani :attribute je nevažeći.',
+    'in_array' => 'Polje :attribute ne postoji u :other.',
+    'integer' => ':attribute mora biti ceo broj.',
+    'ip' => ':attribute mora biti važeća IP adresa.',
+    'ipv4' => ':attribute mora biti važeća IPv4 adresa.',
+    'ipv6' => ':attribute mora biti važeća IPv6 adresa.',
+    'json' => ':attribute mora biti važeći JSON string.',
+    'lt' => [
+        'numeric' => ':attribute mora biti manji od :value.',
+        'file' => ':attribute mora biti manji od :value kilobajta.',
+        'string' => ':attribute mora imati manje od :value karaktera.',
+        'array' => ':attribute mora imati manje od :value stavki.',
+    ],
+    'lte' => [
+        'numeric' => ':attribute mora biti manji ili jednak :value.',
+        'file' => ':attribute mora biti manji ili jednak :value kilobajta.',
+        'string' => ':attribute mora imati najviše :value karaktera.',
+        'array' => ':attribute ne sme imati više od :value stavki.',
+    ],
+    'max' => [
+        'numeric' => ':attribute ne sme biti veći od :max.',
+        'file' => ':attribute ne sme biti veći od :max kilobajta.',
+        'string' => ':attribute ne sme imati više od :max karaktera.',
+        'array' => ':attribute ne sme imati više od :max stavki.',
+    ],
+    'mimes' => ':attribute mora biti fajl tipa: :values.',
+    'mimetypes' => ':attribute mora biti fajl tipa: :values.',
+    'min' => [
+        'numeric' => ':attribute mora biti najmanje :min.',
+        'file' => ':attribute mora biti najmanje :min kilobajta.',
+        'string' => ':attribute mora imati najmanje :min karaktera.',
+        'array' => ':attribute mora imati najmanje :min stavki.',
+    ],
+    'multiple_of' => ':attribute mora biti umnožak vrednosti :value',
+    'not_in' => 'Izabrani :attribute je nevažeći.',
+    'not_regex' => 'Format polja :attribute je nevažeći.',
+    'numeric' => ':attribute mora biti broj.',
+    'password' => 'Lozinka je netačna.',
+    'present' => 'Polje :attribute mora biti prisutno.',
+    'regex' => 'Format polja :attribute je nevažeći.',
+    'required' => 'Polje :attribute je obavezno.',
+    'required_if' => 'Polje :attribute je obavezno kada je :other :value.',
+    'required_unless' => 'Polje :attribute je obavezno osim ako :other nije u :values.',
+    'required_with' => 'Polje :attribute je obavezno kada je prisutno :values.',
+    'required_with_all' => 'Polje :attribute je obavezno kada su prisutne :values.',
+    'required_without' => 'Polje :attribute je obavezno kada :values nije prisutno.',
+    'required_without_all' => 'Polje :attribute je obavezno kada nijedna od :values nije prisutna.',
+    'same' => ':attribute i :other moraju da se poklapaju.',
+    'size' => [
+        'numeric' => ':attribute mora biti :size.',
+        'file' => ':attribute mora biti :size kilobajta.',
+        'string' => ':attribute mora imati :size karaktera.',
+        'array' => ':attribute mora sadržati :size stavki.',
+    ],
+    'starts_with' => ':attribute mora počinjati jednim od sledećih: :values.',
+    'string' => ':attribute mora biti ispravan tekst.',
+    'timezone' => ':attribute mora biti važeća vremenska zona.',
+    'unique' => ':attribute je već zauzet.',
+    'uploaded' => ':attribute nije uspeo da se otpremi.',
+    'url' => 'Format polja :attribute je nevažeći.',
+    'uuid' => ':attribute mora biti važeći UUID.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Language Lines
+    |--------------------------------------------------------------------------
+    */
+
+    'custom' => [
+        'attribute-name' => [
+            'rule-name' => 'prilagođena-poruka',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Attributes
+    |--------------------------------------------------------------------------
+    */
+
+    'attributes' => [],
+
+    'invalid_json' => 'Neispravan unos. Ispravite i pokušajte ponovo.',
+    'invalid_captcha' => 'Nevažeća CAPTCHA. Dokažite da niste robot.',
+    'complete_captcha' => 'Molimo završite captcha.',
+    'yes' => 'Da',
+    'no' => 'Ne',
+
+    'from_date_required' => 'Datum od je obavezan',
+    'to_date_required' => 'Datum do je obavezan',
+    'from_date_before_or_equal' => 'Datum od mora biti pre ili jednak datumu do',
+    'rating_min' => 'Mora biti izabrana ocena',
+    'select_min' => 'Molimo izaberite najmanje :min opcija',
+    'select_max' => 'Molimo izaberite najviše :max opcija',
+];
+

--- a/client/i18n/lang/sr.json
+++ b/client/i18n/lang/sr.json
@@ -1,0 +1,74 @@
+{
+    "app": {
+        "name": "OpnForm"
+    },
+    "forms": {
+        "buttons": {
+            "submit": "Pošalji",
+            "next": "Dalje",
+            "previous": "Nazad",
+            "re_fill": "Pošalji još jedan odgovor"
+        },
+        "powered_by": "Pokreće",
+        "password_protected": "Ovaj formular je zaštićen lozinkom.",
+        "invalid_password": "Neispravna lozinka.",
+        "password_required": "Lozinka je obavezna.",
+        "create_form_free": "Kreiraj svoj formular besplatno uz OpnForm",
+        "submit": "Pošalji",
+        "wrong_form_structure": "Nešto nije u redu sa strukturom ovog formulara. Ako ste vlasnik formulara, kontaktirajte nas.",
+        "cannot_access_here": "Ovom sadržaju nije moguće pristupiti ovde. Kliknite na link ispod za pristup.",
+        "open_form": "Otvori formular",
+        "restricted_to_workspace": "Ograničeno na članove Notion Workspace-a. Prijavite se za pristup ovom sadržaju.",
+        "select": {
+            "search": "Pretraga",
+            "searchOrTypeToCreateNew": "Pretraži ili ukucaj da kreiraš novo",
+            "typeSomethingToAddAnOption": "Ukucaj nešto da dodaš opciju",
+            "noOptionAvailable": "Nema dostupnih opcija",
+            "create": "Kreiraj"
+        },
+        "fileInput": {
+            "chooseFiles": "Kliknite da izaberete fajl(ove) ili prevucite ovde | Kliknite da izaberete fajl ili prevucite ovde",
+            "sizeLimit": "Ograničenje veličine: {count}MB po fajlu",
+            "uploadingFile": "Otpremanje vašeg fajla..."
+        },
+        "cameraUpload": {
+            "allowCameraPermission": "Dozvoli pristup kameri",
+            "allowCameraPermissionDescription": "Morate dozvoliti pristup kameri pre snimanja. Idite u podešavanja pregledača da omogućite pristup kameri na ovoj stranici.",
+            "gotIt": "U redu!",
+            "cameraDeviceError": "Greška uređaja kamere",
+            "cameraDeviceErrorDescription": "Došlo je do nepoznate greške prilikom pokretanja uređaja za kameru.",
+            "goBack": "Nazad"
+        },
+        "signatureInput": {
+            "uploadFileInstead": "Otpremi fajl umesto toga",
+            "clear": "Obriši"
+        },
+        "barcodeInput": {
+            "clickToOpenCamera": "Kliknite da otvorite kameru"
+        },
+        "payment": {
+            "amount_to_pay": "Iznos za plaćanje",
+            "success": "Plaćanje uspešno",
+            "name_on_card": "Ime na kartici",
+            "billing_email": "Email adresa za naplatu",
+            "payment_disclaimer": "Vaša kartica će biti naplaćena klikom na ovo dugme. Plaćanja se bezbedno obrađuju preko Stripe-a.",
+            "errors": {
+                "missingFormOrProvider": "Nedostaje slug formulara ili ID provajdera.",
+                "failedAccountDetails": "Neuspešno preuzimanje Stripe podataka o nalogu.",
+                "setupError": "Došlo je do greške tokom podešavanja Stripe-a.",
+                "systemNotReady": "Sistem plaćanja nije spreman. Sačekajte i pokušajte ponovo.",
+                "misconfigured": "Sistem plaćanja je pogrešno podešen. Osvežite i pokušajte ponovo.",
+                "notFullyReady": "Sistem plaćanja nije u potpunosti spreman. Osvežite i pokušajte ponovo.",
+                "paymentRequired": "Dovršite plaćanje pre nego što nastavite.",
+                "nameRequired": "Ime vlasnika kartice je obavezno.",
+                "emailRequired": "Email adresa za naplatu je obavezna.",
+                "invalidEmail": "Nevažeća email adresa za naplatu.",
+                "failedIntent": "Neuspešno kreiranje namere plaćanja.",
+                "processingFailed": "Obrada plaćanja nije uspela."
+            }
+        },
+        "validation_error": "Greška pri validaciji",
+        "validation_error_with_count": "Greška pri validaciji ({count} polja)"
+    }
+}
+

--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -54,6 +54,7 @@ export default defineNuxtConfig({
         { code: 'sv', name: 'Swedish', iso: 'sv-SE', file: 'sv.json' },
         { code: 'pl', name: 'Polish', iso: 'pl-PL', file: 'pl.json' },
         { code: 'nl', name: 'Dutch', iso: 'nl-NL', file: 'nl.json' },
+        { code: 'sr', name: 'Serbian', iso: 'sr-RS', file: 'sr.json' },
       ],
       defaultLocale: 'en',
       lazy: true,


### PR DESCRIPTION
Add Serbian language support to the app.

This PR introduces Serbian (`sr`) language support across both the backend and frontend, mirroring the implementation for Dutch.

-   **Backend:**
    -   Added `sr` to `Form::LANGUAGES` in `api/app/Models/Forms/Form.php`.
    -   Added `'sr' => 'SR'` to `api/config/app.php` locales.
    -   Created `api/resources/lang/sr/validation.php` with Serbian validation messages.
-   **Frontend:**
    -   Registered Serbian locale in `client/nuxt.config.ts`.
    -   Added `client/i18n/lang/sr.json` with Serbian UI strings.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f84d2cb-c3f5-44df-b343-b69016dcba79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7f84d2cb-c3f5-44df-b343-b69016dcba79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

