### PR TITLE
Enhance template editing permissions in [slug].vue

### DIFF
--- a/client/pages/templates/[slug].vue
+++ b/client/pages/templates/[slug].vue
@@ -340,7 +340,7 @@ const relatedTemplates = computed(() => {
 const showFormTemplateModal = ref(false)
 const { data: user } = useAuth().user()
 const canEditTemplate = computed(
-  () => user.value && (user.value.admin || user.value.template_editor),
+  () => user.value && (user.value.admin || user.value.template_editor || template.value?.creator_id === user.value.id),
 )
 
 const createFormWithTemplateUrl = computed(() => {

--- a/client/test/nuxt/template-slug.component.spec.ts
+++ b/client/test/nuxt/template-slug.component.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest'
+
+/**
+ * Tests for template edit permission logic in templates/[slug].vue
+ * Ensures the edit button is shown only to template owners, admins, and template editors
+ */
+describe('Template Slug Page - canEditTemplate', () => {
+  describe('canEditTemplate computed property', () => {
+    it('should allow admin users to edit any template', () => {
+      const user = { id: 1, admin: true, template_editor: false }
+      const template = { id: 1, creator_id: 999 }
+      
+      const canEdit = user && (user.admin || user.template_editor || template.creator_id === user.id)
+      expect(canEdit).toBe(true)
+    })
+
+    it('should allow template_editor users to edit any template', () => {
+      const user = { id: 1, admin: false, template_editor: true }
+      const template = { id: 1, creator_id: 999 }
+      
+      const canEdit = user && (user.admin || user.template_editor || template.creator_id === user.id)
+      expect(canEdit).toBe(true)
+    })
+
+    it('should allow template creator to edit their own template', () => {
+      const user = { id: 1, admin: false, template_editor: false }
+      const template = { id: 1, creator_id: 1 }
+      
+      const canEdit = user && (user.admin || user.template_editor || template.creator_id === user.id)
+      expect(canEdit).toBe(true)
+    })
+
+    it('should not allow non-creator, non-admin users to edit templates', () => {
+      const user = { id: 1, admin: false, template_editor: false }
+      const template = { id: 1, creator_id: 999 }
+      
+      const canEdit = user && (user.admin || user.template_editor || template.creator_id === user.id)
+      expect(canEdit).toBe(false)
+    })
+
+    it('should not allow unauthenticated users to edit templates', () => {
+      const user = null
+      const template = { id: 1, creator_id: 999 }
+      
+      const canEdit = user && (user.admin || user.template_editor || template.creator_id === user.id)
+      expect(canEdit).toBe(null)
+    })
+
+    it('should require creator_id match when user has no special roles', () => {
+      const user = { id: 2, admin: false, template_editor: false }
+      const template = { id: 1, creator_id: 2 }
+      
+      const canEdit = user && (user.admin || user.template_editor || template.creator_id === user.id)
+      expect(canEdit).toBe(true)
+    })
+
+    it('should reject when creator_id does not match and no special roles', () => {
+      const user = { id: 2, admin: false, template_editor: false }
+      const template = { id: 1, creator_id: 3 }
+      
+      const canEdit = user && (user.admin || user.template_editor || template.creator_id === user.id)
+      expect(canEdit).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
- Updated the `canEditTemplate` computed property to include a check for the template creator's ID, allowing the creator to edit their own templates in addition to admin and template editor roles.

This change improves user experience by ensuring that template creators have the necessary permissions to manage their own content.

Closing https://github.com/JhumanJ/OpnForm/issues/923

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Template creators now have the ability to edit their own templates, in addition to existing edit permissions for administrators and template editors.

* **Tests**
  * Added test coverage validating template edit permissions based on user roles and authentication status, including edge case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->