### PR TITLE
Update BlockRenderer component to use dynamic keys for media blocks

### DIFF
--- a/client/components/open/forms/BlockRenderer.vue
+++ b/client/components/open/forms/BlockRenderer.vue
@@ -44,7 +44,7 @@
     <div
       v-else-if="block.type === 'nf-image' && (isAdminPreview || (!isAdminPreview && block.image_block))"
       :id="block.id"
-      :key="block.id"
+      :key="'image-' + block.id"
       class="my-4 w-full"
       :class="[getFieldAlignClasses(block)]"
       @dblclick="editFieldOptions"
@@ -68,9 +68,9 @@
       >
     </div>
     <div
-      v-if="block.type === 'nf-video' && (isAdminPreview || (!isAdminPreview && block.video_block))"
+      v-else-if="block.type === 'nf-video' && (isAdminPreview || (!isAdminPreview && block.video_block))"
       :id="block.id"
-      :key="block.id"
+      :key="'video-' + block.id"
       class="my-4 w-full"
       :class="[getFieldAlignClasses(block)]"
       @dblclick="editFieldOptions"


### PR DESCRIPTION
- Modified the key binding for image and video blocks in BlockRenderer.vue to prepend 'image-' and 'video-' to the block IDs, enhancing the uniqueness of keys and improving rendering performance.
- Adjusted conditional rendering logic for video blocks to ensure proper handling based on admin preview states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized rendering logic for image and video blocks to improve component performance and control flow consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->