### PR TITLE
ESC-753 = Refactor file name handling in StorageFileNameParser

### DIFF
--- a/api/app/Service/Storage/StorageFileNameParser.php
+++ b/api/app/Service/Storage/StorageFileNameParser.php
@@ -30,7 +30,7 @@ class StorageFileNameParser
     public function getMovedFileName(): ?string
     {
         if ($this->fileName && $this->extension) {
-            $fileName = substr($this->fileName, 0, 50) . '_' . $this->uuid . '.' . $this->extension;
+            $fileName = mb_substr($this->fileName, 0, 50) . '_' . $this->uuid . '.' . $this->extension;
             $fileName = preg_replace('#\p{C}+#u', '', $fileName); // avoid CorruptedPathDetected exceptions
 
             return $fileName ? S3KeyCleaner::sanitize($fileName) : null;


### PR DESCRIPTION
- Replaced `substr` with `mb_substr` in the `getMovedFileName` method to ensure proper handling of multibyte character strings, enhancing compatibility with various file name encodings.