### PR TITLE
Fix optional chaining in language watcher for OpenCompleteForm.vue

### DIFF
--- a/client/components/open/forms/OpenCompleteForm.vue
+++ b/client/components/open/forms/OpenCompleteForm.vue
@@ -284,7 +284,7 @@ useHead({
   )
 })
 
-watch(() => props.form.language, (newLanguage) => {
+watch(() => props.form?.language, (newLanguage) => {
   if (newLanguage && typeof newLanguage === 'string') {
     setLocale(newLanguage)
   } else {


### PR DESCRIPTION
Fix #987 