### PR TITLE
Add customer name editing to admin billing info

### DIFF
--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -289,8 +289,8 @@ Route::group(['middleware' => 'auth.multi'], function () {
         );
 
         Route::group(['prefix'  => 'billing'], function () {
-            Route::get('{user}/email', [\App\Http\Controllers\Admin\BillingController::class, 'getEmail']);
-            Route::patch('/email', [\App\Http\Controllers\Admin\BillingController::class, 'updateEmail']);
+            Route::get('{user}/customer', [\App\Http\Controllers\Admin\BillingController::class, 'getCustomer']);
+            Route::patch('/customer', [\App\Http\Controllers\Admin\BillingController::class, 'updateCustomer']);
             Route::get('{user}/subscriptions', [\App\Http\Controllers\Admin\BillingController::class, 'getSubscriptions']);
             Route::get('{user}/payments', [\App\Http\Controllers\Admin\BillingController::class, 'getPayments']);
         });

--- a/client/api/admin.js
+++ b/client/api/admin.js
@@ -20,8 +20,8 @@ export const adminApi = {
 
   // Billing management
   billing: {
-    getEmail: (userId, options) => apiService.get(`${BASE_PATH}/billing/${userId}/email`, options),
-    updateEmail: (data) => apiService.patch(`${BASE_PATH}/billing/email`, data),
+    getCustomer: (userId, options) => apiService.get(`${BASE_PATH}/billing/${userId}/customer`, options),
+    updateCustomer: (data) => apiService.patch(`${BASE_PATH}/billing/customer`, data),
     getSubscriptions: (userId, options) => apiService.get(`${BASE_PATH}/billing/${userId}/subscriptions`, options),
     getPayments: (userId, options) => apiService.get(`${BASE_PATH}/billing/${userId}/payments`, options)
   },

--- a/client/pages/admin.vue
+++ b/client/pages/admin.vue
@@ -127,7 +127,7 @@
         <ExtendTrial
           :user="userInfo"
         />
-        <BillingEmail
+        <BillingCustomer
           :user="userInfo"
         />
         <UserWorkspaces


### PR DESCRIPTION
## Summary
- Extends the existing admin billing email feature to also allow editing the Stripe customer name
- Consolidates email and name fields into a single "Billing info" card with one API endpoint
- Pre-fills both fields with current Stripe values for the customer

## Test plan
- [ ] Navigate to admin page and search for a user with a Stripe subscription
- [ ] Verify the "Billing info" card shows with both name and email fields pre-filled
- [ ] Update the name and/or email and verify the success message
- [ ] Confirm changes are reflected in Stripe dashboard

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a unified admin flow to manage Stripe customer details (name and email) instead of email-only.
> 
> - `BillingController`: rename `getEmail`/`updateEmail` to `getCustomer`/`updateCustomer`; now returns/updates `billing_name` and `billing_email`
> - Routes: `/moderator/billing/{user}/customer` (GET) and `/moderator/billing/customer` (PATCH) replace prior `/email` endpoints
> - Client API: `adminApi.billing.getCustomer`/`updateCustomer` replace email methods
> - UI: replace `BillingEmail` card with `BillingCustomer` showing name and email fields, prefilled from Stripe; admin page updated to use the new component
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 151ce95889aafc9c6b06162e048a8380ea8f03c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->