### PR TITLE
ESC-783 : Add rich text comparators to open_filters.json and update ColumnCondi…

### DIFF
--- a/api/resources/data/open_filters.json
+++ b/api/resources/data/open_filters.json
@@ -343,6 +343,92 @@
       }
     }
   },
+  "rich_text": {
+    "comparators": {
+      "equals": {
+        "expected_type": "string"
+      },
+      "does_not_equal": {
+        "expected_type": "string"
+      },
+      "contains": {
+        "expected_type": "string"
+      },
+      "does_not_contain": {
+        "expected_type": "string"
+      },
+      "starts_with": {
+        "expected_type": "string"
+      },
+      "ends_with": {
+        "expected_type": "string"
+      },
+      "is_empty": {
+        "expected_type": "boolean",
+        "format": {
+          "type": "enum",
+          "values": [
+            true
+          ]
+        }
+      },
+      "is_not_empty": {
+        "expected_type": "boolean",
+        "format": {
+          "type": "enum",
+          "values": [
+            true
+          ]
+        }
+      },
+      "content_length_equals": {
+        "expected_type": "number"
+      },
+      "content_length_does_not_equal": {
+        "expected_type": "number"
+      },
+      "content_length_greater_than": {
+        "expected_type": "number"
+      },
+      "content_length_greater_than_or_equal_to": {
+        "expected_type": "number"
+      },
+      "content_length_less_than": {
+        "expected_type": "number"
+      },
+      "content_length_less_than_or_equal_to": {
+        "expected_type": "number"
+      },
+      "matches_regex": {
+        "expected_type": "string",
+        "format": {
+          "type": "regex"
+        }
+      },
+      "does_not_match_regex": {
+        "expected_type": "string",
+        "format": {
+          "type": "regex"
+        }
+      },
+      "exists_in_submissions": {
+        "expected_type": "boolean",
+        "format": {
+          "type": "enum",
+          "values": [true]
+        },
+        "custom_validation_only": true
+      },
+      "does_not_exist_in_submissions": {
+        "expected_type": "boolean",
+        "format": {
+          "type": "enum",
+          "values": [true]
+        },
+        "custom_validation_only": true
+      }
+    }
+  },
   "matrix": {
     "comparators": {
       "equals": {

--- a/client/components/open/forms/components/form-logic-components/ColumnCondition.vue
+++ b/client/components/open/forms/components/form-logic-components/ColumnCondition.vue
@@ -60,6 +60,7 @@ export default {
       hasInput: false,
       inputComponent: {
         text: "TextInput",
+        rich_text: "TextInput",
         number: "TextInput",
         rating: "TextInput",
         scale: "TextInput",

--- a/client/data/open_filters.json
+++ b/client/data/open_filters.json
@@ -343,6 +343,92 @@
       }
     }
   },
+  "rich_text": {
+    "comparators": {
+      "equals": {
+        "expected_type": "string"
+      },
+      "does_not_equal": {
+        "expected_type": "string"
+      },
+      "contains": {
+        "expected_type": "string"
+      },
+      "does_not_contain": {
+        "expected_type": "string"
+      },
+      "starts_with": {
+        "expected_type": "string"
+      },
+      "ends_with": {
+        "expected_type": "string"
+      },
+      "is_empty": {
+        "expected_type": "boolean",
+        "format": {
+          "type": "enum",
+          "values": [
+            true
+          ]
+        }
+      },
+      "is_not_empty": {
+        "expected_type": "boolean",
+        "format": {
+          "type": "enum",
+          "values": [
+            true
+          ]
+        }
+      },
+      "content_length_equals": {
+        "expected_type": "number"
+      },
+      "content_length_does_not_equal": {
+        "expected_type": "number"
+      },
+      "content_length_greater_than": {
+        "expected_type": "number"
+      },
+      "content_length_greater_than_or_equal_to": {
+        "expected_type": "number"
+      },
+      "content_length_less_than": {
+        "expected_type": "number"
+      },
+      "content_length_less_than_or_equal_to": {
+        "expected_type": "number"
+      },
+      "matches_regex": {
+        "expected_type": "string",
+        "format": {
+          "type": "regex"
+        }
+      },
+      "does_not_match_regex": {
+        "expected_type": "string",
+        "format": {
+          "type": "regex"
+        }
+      },
+      "exists_in_submissions": {
+        "expected_type": "boolean",
+        "format": {
+          "type": "enum",
+          "values": [true]
+        },
+        "custom_validation_only": true
+      },
+      "does_not_exist_in_submissions": {
+        "expected_type": "boolean",
+        "format": {
+          "type": "enum",
+          "values": [true]
+        },
+        "custom_validation_only": true
+      }
+    }
+  },
   "matrix": {
     "comparators": {
       "equals": {


### PR DESCRIPTION
…tion.vue

- Introduced new comparators for rich text fields in open_filters.json, enhancing validation capabilities with options like 'contains', 'starts_with', and regex matching.
- Updated ColumnCondition.vue to include 'rich_text' as a valid input component type, ensuring compatibility with the new comparators.

These changes improve the flexibility and functionality of form validation for rich text inputs.