### PR TITLE
SMTP settings precedence

### DIFF
--- a/api/app/Notifications/Forms/FormEmailNotification.php
+++ b/api/app/Notifications/Forms/FormEmailNotification.php
@@ -8,6 +8,7 @@ use App\Service\Forms\FormSubmissionFormatter;
 use App\Service\Forms\SubmissionUrlService;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Str;
 use Symfony\Component\Mime\Email;
 
@@ -45,6 +46,11 @@ class FormEmailNotification extends Notification
                 'mail.mailers.custom_smtp.username' => $emailSettings['username'],
                 'mail.mailers.custom_smtp.password' => $emailSettings['password']
             ]);
+
+            // Laravel caches mailer instances (and their transport) in long-lived processes
+            // like queue workers (Horizon). If workspace SMTP settings change, we must purge
+            // the cached mailer so the next send uses the updated config.
+            Mail::purge('custom_smtp');
             return 'custom_smtp';
         }
 


### PR DESCRIPTION
Purge cached `custom_smtp` mailer to apply workspace SMTP settings changes immediately.

Long-lived PHP processes (like queue workers) cache mailer instances and their SMTP transport. This change ensures that when workspace SMTP settings are updated, the `custom_smtp` mailer is purged, forcing it to be rebuilt with the latest configuration without requiring a container restart.

---
<a href="https://cursor.com/background-agent?bcId=bc-efefe4fd-c0d7-46f6-b41a-659cefa40d57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-efefe4fd-c0d7-46f6-b41a-659cefa40d57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

