### PR TITLE
[codex] Harden notification rendering

### DIFF
--- a/api/app/Integrations/Handlers/DiscordIntegration.php
+++ b/api/app/Integrations/Handlers/DiscordIntegration.php
@@ -57,7 +57,7 @@ class DiscordIntegration extends AbstractIntegrationHandler
             if (Arr::get($settings, 'include_hidden_fields_submission_data', false)) {
                 $formatter->showHiddenFields();
             }
-            $formattedData = $formatter->getFieldsWithValue();
+            $formattedData = $this->escapeFormattedDataForDiscord($formatter->getFieldsWithValue());
 
             $submissionString = '';
             foreach ($formattedData as $field) {
@@ -89,7 +89,9 @@ class DiscordIntegration extends AbstractIntegrationHandler
             ];
         }
 
-        $formattedData = (new FormSubmissionFormatter($this->form, $this->submissionData))->outputStringsOnly()->showHiddenFields()->getFieldsWithValue();
+        $formattedData = $this->escapeFormattedDataForDiscord(
+            (new FormSubmissionFormatter($this->form, $this->submissionData))->outputStringsOnly()->showHiddenFields()->getFieldsWithValue()
+        );
         $message = Arr::get($settings, 'message', 'New form submission');
         return [
             'content' => (new MentionParser($message, $formattedData))->parse(),
@@ -98,5 +100,24 @@ class DiscordIntegration extends AbstractIntegrationHandler
             'avatar_url' => asset('img/logo.png'),
             'embeds' => $blocks,
         ];
+    }
+
+    private function escapeFormattedDataForDiscord(array $fields): array
+    {
+        return array_map(function (array $field) {
+            $field['value'] = is_array($field['value'] ?? null)
+                ? array_map([$this, 'escapeDiscordMarkdownText'], $field['value'])
+                : $this->escapeDiscordMarkdownText((string) ($field['value'] ?? ''));
+
+            return $field;
+        }, $fields);
+    }
+
+    private function escapeDiscordMarkdownText(string $text): string
+    {
+        $text = str_replace('\\', '\\\\', $text);
+        $text = preg_replace('/([*_~`>|\\[\\]()])/u', '\\\\$1', $text);
+
+        return str_replace('@', "@\u{200B}", $text);
     }
 }

--- a/api/app/Integrations/Handlers/SlackIntegration.php
+++ b/api/app/Integrations/Handlers/SlackIntegration.php
@@ -50,7 +50,9 @@ class SlackIntegration extends AbstractIntegrationHandler
             $externalLinks[] = '*<' . $editUrl . '|✍️ ' . $this->form->editable_submissions_button_text . '>*';
         }
 
-        $formattedData = (new FormSubmissionFormatter($this->form, $this->submissionData))->outputStringsOnly()->showHiddenFields()->getFieldsWithValue();
+        $formattedData = $this->escapeFormattedDataForSlack(
+            (new FormSubmissionFormatter($this->form, $this->submissionData))->outputStringsOnly()->showHiddenFields()->getFieldsWithValue()
+        );
         $message = Arr::get($settings, 'message', 'New form submission');
         $blocks = [
             [
@@ -67,7 +69,7 @@ class SlackIntegration extends AbstractIntegrationHandler
             if (Arr::get($settings, 'include_hidden_fields_submission_data', false)) {
                 $formatter->showHiddenFields();
             }
-            $formattedData = $formatter->getFieldsWithValue();
+            $formattedData = $this->escapeFormattedDataForSlack($formatter->getFieldsWithValue());
 
             $submissionString = '';
             foreach ($formattedData as $field) {
@@ -108,5 +110,25 @@ class SlackIntegration extends AbstractIntegrationHandler
         return [
             'blocks' => $blocks,
         ];
+    }
+
+    private function escapeFormattedDataForSlack(array $fields): array
+    {
+        return array_map(function (array $field) {
+            $field['value'] = is_array($field['value'] ?? null)
+                ? array_map([$this, 'escapeSlackMrkdwnText'], $field['value'])
+                : $this->escapeSlackMrkdwnText((string) ($field['value'] ?? ''));
+
+            return $field;
+        }, $fields);
+    }
+
+    private function escapeSlackMrkdwnText(string $text): string
+    {
+        return str_replace(
+            ['&', '<', '>'],
+            ['&amp;', '&lt;', '&gt;'],
+            $text
+        );
     }
 }

--- a/api/app/Service/Forms/FormSubmissionFormatter.php
+++ b/api/app/Service/Forms/FormSubmissionFormatter.php
@@ -210,9 +210,11 @@ class FormSubmissionFormatter
             }
 
             if ($this->createLinks && $field['type'] == 'url') {
-                $field['value'] = '<a href="' . $data[$field['id']] . '">' . $data[$field['id']] . '</a>';
+                $field['value'] = $this->formatUrlLink($data[$field['id']]);
+                $field['value_is_html'] = true;
             } elseif ($this->createLinks && $field['type'] == 'email') {
-                $field['value'] = '<a href="mailto:' . $data[$field['id']] . '">' . $data[$field['id']] . '</a>';
+                $field['value'] = $this->formatEmailLink($data[$field['id']]);
+                $field['value_is_html'] = true;
             } elseif ($field['type'] == 'checkbox') {
                 $field['value'] = $data[$field['id']] ? trans('validation.yes') : trans('validation.no');
             } elseif ($field['type'] == 'date') {
@@ -243,8 +245,9 @@ class FormSubmissionFormatter
                     })->toArray();
                     if ($this->createLinks) {
                         $field['value'] = implode(', ', collect($files)->map(function ($file) {
-                            return '<a href="' . $file . '">' . $file . '</a>';
+                            return $this->buildSafeHtmlLink($file, $file);
                         })->toArray());
+                        $field['value_is_html'] = true;
                     } else {
                         $field['value'] = implode(', ', $files);
                     }
@@ -274,10 +277,55 @@ class FormSubmissionFormatter
                     $field['value'] = $data[$field['id']];
                 }
             }
+
+            if ($this->createLinks && empty($field['value_is_html'])) {
+                $field['value'] = $this->escapeHtmlValue($field['value']);
+            }
+
             $transformedFields[] = $field;
         }
 
         return $transformedFields;
+    }
+
+    private function formatUrlLink(mixed $value): string
+    {
+        $url = is_scalar($value) ? (string) $value : '';
+
+        if (!filter_var($url, FILTER_VALIDATE_URL)) {
+            return $this->escapeHtmlValue($value);
+        }
+
+        return $this->buildSafeHtmlLink($url, $url);
+    }
+
+    private function formatEmailLink(mixed $value): string
+    {
+        $email = is_scalar($value) ? (string) $value : '';
+
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            return $this->escapeHtmlValue($value);
+        }
+
+        return $this->buildSafeHtmlLink('mailto:' . $email, $email);
+    }
+
+    private function buildSafeHtmlLink(string $href, string $label): string
+    {
+        return '<a href="' . e($href) . '">' . e($label) . '</a>';
+    }
+
+    private function escapeHtmlValue(mixed $value): string
+    {
+        if (is_array($value)) {
+            $value = implode(', ', $value);
+        } elseif (is_bool($value)) {
+            $value = $value ? '1' : '0';
+        } elseif ($value === null) {
+            $value = '';
+        }
+
+        return e((string) $value);
     }
 
     private function initIdFormData()

--- a/api/resources/views/mail/form/email-notification.blade.php
+++ b/api/resources/views/mail/form/email-notification.blade.php
@@ -16,7 +16,11 @@
 @if(isset($field['value']))
 <p style="white-space: pre-wrap; border-top: 1px solid #9ca3af;">
     <b>{{$field['name']}}</b>
-    {!! is_array($field['value'])?implode(',',$field['value']):$field['value']!!}
+    @if(!empty($field['value_is_html']))
+    {!! $field['value'] !!}
+    @else
+    {{ is_array($field['value']) ? implode(',', $field['value']) : $field['value'] }}
+    @endif
 </p>
 @endif
 @endforeach

--- a/api/tests/Feature/Integrations/Email/EmailIntegrationTest.php
+++ b/api/tests/Feature/Integrations/Email/EmailIntegrationTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Models\Integration\FormIntegration;
+use App\Notifications\Forms\FormEmailNotification;
+use Illuminate\Notifications\AnonymousNotifiable;
 
 test('free user can create one email integration to their own email', function () {
     $user = $this->actingAsUser();
@@ -383,4 +385,39 @@ test('pro user can update email integration with email appearance settings', fun
     expect($integration->data->font_color)->toBe('#333333');
     expect($integration->data->outer_background_color)->toBe('#e0e0e0');
     expect($integration->data->inner_background_color)->toBe('#fafafa');
+});
+
+test('email notification escapes submission html while keeping generated links clickable', function () {
+    $user = $this->actingAsProUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace);
+
+    $textField = collect($form->properties)->firstWhere('name', 'Name');
+    $urlField = collect($form->properties)->firstWhere('name', 'URL');
+
+    $submissionData = [
+        $textField['id'] => 'normal <b>bold</b> <img src="https://evil.test/pixel.png">',
+        $urlField['id'] => 'https://example.com/path',
+    ];
+
+    $integrationData = (object) [
+        'sender_name' => 'Test Sender',
+        'subject' => 'Test Subject',
+        'email_content' => '<p>Body: <span mention="true" mention-field-id="' . $textField['id'] . '"></span></p>',
+        'include_submission_data' => true,
+    ];
+
+    $notification = new FormEmailNotification(
+        new \App\Events\Forms\FormSubmitted($form, $submissionData),
+        $integrationData
+    );
+
+    $html = (string) $notification->toMail(new AnonymousNotifiable())->render();
+
+    expect($html)->toContain('normal &lt;b&gt;bold&lt;/b&gt;');
+    expect($html)->toContain('evil.test/pixel.png');
+    expect($html)->not->toContain('normal <b>bold</b>');
+    expect($html)->not->toContain('<img src="https://evil.test/pixel.png">');
+    expect($html)->toContain('href="https://example.com/path"');
+    expect($html)->toContain('>https://example.com/path<');
 });

--- a/api/tests/Feature/Integrations/RichTextIntegrationEscapingTest.php
+++ b/api/tests/Feature/Integrations/RichTextIntegrationEscapingTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use App\Events\Forms\FormSubmitted;
+use App\Integrations\Handlers\DiscordIntegration;
+use App\Integrations\Handlers\SlackIntegration;
+use App\Models\Integration\FormIntegration;
+
+test('slack integration escapes submission values in mrkdwn blocks', function () {
+    $user = $this->actingAsProUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace);
+
+    $textField = collect($form->properties)->firstWhere('name', 'Name');
+    $submissionData = [
+        $textField['id'] => '<http://evil.test|Click me>',
+    ];
+
+    $integration = FormIntegration::factory()->make([
+        'form_id' => $form->id,
+        'integration_id' => 'slack',
+        'data' => [
+            'slack_webhook_url' => 'https://hooks.slack.com/services/test/test/test',
+            'message' => 'Hello <span mention="true" mention-field-id="' . $textField['id'] . '"></span>',
+            'include_submission_data' => true,
+        ],
+    ]);
+
+    $handler = new class (new FormSubmitted($form, $submissionData), $integration, ['name' => 'Slack']) extends SlackIntegration {
+        public function payload(): array
+        {
+            return $this->getWebhookData();
+        }
+    };
+
+    $payload = $handler->payload();
+    $text = $payload['blocks'][0]['text']['text'] . "\n" . $payload['blocks'][1]['text']['text'];
+
+    expect($text)->toContain('&lt;http://evil.test|Click me&gt;');
+    expect($text)->not->toContain('<http://evil.test|Click me>');
+});
+
+test('discord integration escapes submission values in content and embeds', function () {
+    $user = $this->actingAsProUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace);
+
+    $textField = collect($form->properties)->firstWhere('name', 'Name');
+    $submissionData = [
+        $textField['id'] => '[@everyone](https://evil.test)',
+    ];
+
+    $integration = FormIntegration::factory()->make([
+        'form_id' => $form->id,
+        'integration_id' => 'discord',
+        'data' => [
+            'discord_webhook_url' => 'https://discord.com/api/webhooks/test/test',
+            'message' => 'Hello <span mention="true" mention-field-id="' . $textField['id'] . '"></span>',
+            'include_submission_data' => true,
+        ],
+    ]);
+
+    $handler = new class (new FormSubmitted($form, $submissionData), $integration, ['name' => 'Discord']) extends DiscordIntegration {
+        public function payload(): array
+        {
+            return $this->getWebhookData();
+        }
+    };
+
+    $payload = $handler->payload();
+
+    expect($payload['content'])->toContain('\\[@​everyone\\]\\(https://evil.test\\)');
+    expect($payload['content'])->not->toContain('[@everyone](https://evil.test)');
+    expect($payload['embeds'][0]['description'])->toContain('\\[@​everyone\\]\\(https://evil.test\\)');
+});


### PR DESCRIPTION
## What changed

This hardens notification rendering so respondent-supplied content is treated as plain text instead of rich markup in notification channels.

- escape submission values in email notification rendering
- preserve system-generated links in emails for URL, email, and file fields
- escape respondent values before interpolation in Slack mrkdwn payloads
- escape respondent values before interpolation in Discord content and embed descriptions
- add regression coverage for email, Slack, and Discord notification rendering

## Why

A form respondent could submit HTML or rich-text-like payloads that were preserved in outgoing notifications. In email notifications this allowed raw tags such as `<b>`, `<a>`, or `<img>` to survive into the rendered message. In Slack and Discord, respondent-controlled content could also be interpreted by the target platform's rich text formatting.

This change keeps administrator-authored email content intact, but ensures respondent data is escaped before it is rendered or interpolated into notification payloads.

## Impact

- reduces phishing and spoofing risk in internal notification emails
- prevents respondent-controlled formatting from being interpreted in Slack and Discord notifications
- keeps existing system-generated links working where they are intended

## Validation

- `php -l api/app/Service/Forms/FormSubmissionFormatter.php`
- `php -l api/resources/views/mail/form/email-notification.blade.php`
- `php -l api/app/Integrations/Handlers/SlackIntegration.php`
- `php -l api/app/Integrations/Handlers/DiscordIntegration.php`
- `php -l api/tests/Feature/Integrations/Email/EmailIntegrationTest.php`
- `php -l api/tests/Feature/Integrations/RichTextIntegrationEscapingTest.php`

## Notes

I could not run the backend test suite in this environment because the API test bootstrap fails early with `Mpociot\\Versionable\\VersionableTrait not found`.
