### PR TITLE
refactor: optimize form route binding for file downloads

### DIFF
--- a/api/app/Providers/AppServiceProvider.php
+++ b/api/app/Providers/AppServiceProvider.php
@@ -57,7 +57,12 @@ class AppServiceProvider extends ServiceProvider
 
         Route::bind('form', function ($value) {
             // Support both numeric ID and slug resolution (compact, common part outside ternary)
-            $query = \App\Models\Forms\Form::with(['workspace.users' => fn ($q) => $q->withPivot('role')]);
+            $query = \App\Models\Forms\Form::query();
+            // Signed file downloads only need the form id for storage path — skip eager loads.
+            $route = request()->route();
+            if (! $route?->named('open.forms.submissions.file')) {
+                $query->with(['workspace.users' => fn ($q) => $q->withPivot('role')]);
+            }
             return is_numeric($value)
                 ? $query->findOrFail((int) $value)
                 : $query->where('slug', $value)->firstOrFail();

--- a/api/tests/Feature/Forms/FileDownloadSecurityTest.php
+++ b/api/tests/Feature/Forms/FileDownloadSecurityTest.php
@@ -3,6 +3,7 @@
 use App\Models\Forms\FormSubmission;
 use App\Service\Storage\FileUploadPathService;
 use App\Service\Storage\FilenameUrlEncoder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\URL;
 
@@ -40,4 +41,41 @@ it('forces attachment download with safe headers for submission files', function
         ->toBe('application/octet-stream');
     expect($response->headers->get('x-content-type-options'))
         ->toBe('nosniff');
+});
+
+it('does not eager load workspace users for signed submission file downloads', function () {
+    $user = $this->actingAsUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace);
+
+    $extraUser = \App\Models\User::factory()->create();
+    $workspace->users()->attach($extraUser->id, ['role' => 'user']);
+
+    Storage::fake();
+
+    $fileName = 'test_file_' . uniqid() . '.pdf';
+    $path = FileUploadPathService::getFileUploadPath($form->id, $fileName);
+    Storage::put($path, 'test pdf content');
+
+    $form->submissions()->create([
+        'form_id' => $form->id,
+        'data' => [
+            'files_field' => [$fileName],
+        ],
+        'status' => FormSubmission::STATUS_COMPLETED,
+    ]);
+
+    $encodedFilename = FilenameUrlEncoder::encode($fileName);
+    $signedUrl = URL::signedRoute('open.forms.submissions.file', [$form->id, $encodedFilename]);
+
+    DB::flushQueryLog();
+    DB::enableQueryLog();
+
+    $this->get($signedUrl)->assertOk();
+
+    $queries = collect(DB::getQueryLog())
+        ->pluck('query')
+        ->map(fn (string $sql) => strtolower($sql));
+
+    expect($queries->contains(fn (string $sql) => str_contains($sql, 'user_workspace')))->toBeFalse();
 });


### PR DESCRIPTION
Updated the form route binding logic to conditionally skip eager loading of related workspace users when accessing signed file downloads. This change improves performance by reducing unnecessary data retrieval for specific routes.

Sentry - 6902587743