### PR TITLE
Improve Stripe tax export accuracy

### DIFF
--- a/api/app/Console/Commands/Tax/CollectStripeExportDatasetChunk.php
+++ b/api/app/Console/Commands/Tax/CollectStripeExportDatasetChunk.php
@@ -21,8 +21,7 @@ class CollectStripeExportDatasetChunk extends Command
         StripeExportDatasetService $collector,
         StripeExportDatasetStore $store,
         StripeBalanceSummaryService $balanceSummaryService
-    ): int
-    {
+    ): int {
         $datasetId = (string) $this->option('dataset');
         $startDate = (string) $this->option('start-date');
         $endDate = (string) $this->option('end-date');

--- a/api/app/Console/Commands/Tax/CollectStripeExportDatasetChunk.php
+++ b/api/app/Console/Commands/Tax/CollectStripeExportDatasetChunk.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands\Tax;
 
+use App\Services\Tax\StripeBalanceSummaryService;
 use App\Services\Tax\StripeExportDatasetService;
 use App\Services\Tax\StripeExportDatasetStore;
 use Illuminate\Console\Command;
@@ -16,7 +17,11 @@ class CollectStripeExportDatasetChunk extends Command
 
     protected $description = 'Collect a single Stripe export dataset chunk';
 
-    public function handle(StripeExportDatasetService $collector, StripeExportDatasetStore $store): int
+    public function handle(
+        StripeExportDatasetService $collector,
+        StripeExportDatasetStore $store,
+        StripeBalanceSummaryService $balanceSummaryService
+    ): int
     {
         $datasetId = (string) $this->option('dataset');
         $startDate = (string) $this->option('start-date');
@@ -34,13 +39,15 @@ class CollectStripeExportDatasetChunk extends Command
         ], now()->addDay());
 
         $payload = $collector->collect($startDate, $endDate);
-        $store->writeChunk($datasetId, $chunkKey, $payload['rows'], $payload['stats']);
+        $balanceSummary = $balanceSummaryService->summarize($startDate, $endDate);
+        $store->writeChunk($datasetId, $chunkKey, $payload['rows'], $payload['stats'], $balanceSummary);
 
         Cache::put("stripe-export-dataset:{$datasetId}:{$chunkKey}", [
             'status' => 'completed',
             'completed_at' => now()->toIso8601String(),
             'row_count' => count($payload['rows']),
             'stats' => $payload['stats'],
+            'balance_summary' => $balanceSummary,
         ], now()->addDay());
 
         $this->info("Collected {$chunkKey}: " . count($payload['rows']) . ' rows');

--- a/api/app/Console/Commands/Tax/GenerateDesXmlExport.php
+++ b/api/app/Console/Commands/Tax/GenerateDesXmlExport.php
@@ -117,7 +117,7 @@ class GenerateDesXmlExport extends Command
                 'country_code' => $row['des_country_code'],
                 'vat_number' => $row['des_vat_number'],
                 'amount_eur' => $row['des_amount_eur'],
-                'created_at' => $row['created_ts'],
+                'created_at' => $row['accounting_ts'] ?? $row['created_ts'],
             ];
         }, $rows)));
 

--- a/api/app/Console/Commands/Tax/GenerateTaxExport.php
+++ b/api/app/Console/Commands/Tax/GenerateTaxExport.php
@@ -3,11 +3,11 @@
 namespace App\Console\Commands\Tax;
 
 use App\Exports\Tax\ArrayExport;
+use App\Services\Tax\StripeBalanceSummaryService;
 use App\Services\Tax\StripeExportDatasetService;
 use App\Services\Tax\StripeExportDatasetStore;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
-use Laravel\Cashier\Cashier;
 use Stripe\Invoice;
 
 class GenerateTaxExport extends Command
@@ -65,7 +65,11 @@ class GenerateTaxExport extends Command
      *
      * @return int
      */
-    public function handle(StripeExportDatasetService $collector, StripeExportDatasetStore $store)
+    public function handle(
+        StripeExportDatasetService $collector,
+        StripeExportDatasetStore $store,
+        StripeBalanceSummaryService $balanceSummaryService
+    )
     {
         // Start the processing timer
         $startTime = microtime(true);
@@ -110,6 +114,15 @@ class GenerateTaxExport extends Command
         $processedInvoices = array_map(fn (array $row) => $collector->toTaxExportRow($row), $datasetRows);
 
         $aggregatedReport = $this->aggregateReport($processedInvoices);
+        $balanceSummary = $this->resolveBalanceSummary(
+            $startDate,
+            $endDate,
+            $datasetId ? (string) $datasetId : null,
+            $stats,
+            $store,
+            $balanceSummaryService
+        );
+        $aggregatedReport = $this->appendReconciliationRows($aggregatedReport, $balanceSummary);
 
         $filePath = 'opnform-tax-export-per-invoice_' . $startDate . '_' . $endDate . '.xlsx';
         $this->exportAsXlsx($processedInvoices, $filePath);
@@ -128,6 +141,7 @@ class GenerateTaxExport extends Command
         $this->info('Excluded invoices:');
         $this->info(' - Payment not successful: ' . ($stats['payment_not_successful_count'] ?? 0));
         $this->info(' - Refunded / fully credited: ' . ($stats['refunded_invoices_count'] ?? 0));
+        $this->info(' - Disputed: ' . ($stats['disputed_invoices_count'] ?? 0));
         $this->info(' - Missing required data: ' . ($stats['missing_data_invoices_count'] ?? 0));
         $this->info(' - Defaulted to France: ' . ($stats['defaulted_to_fr_count'] ?? 0));
 
@@ -153,6 +167,15 @@ class GenerateTaxExport extends Command
         $this->line('');
         $this->comment('Note: EUR amounts are GROSS (before Stripe fees) to match Stripe Dashboard.');
         $this->comment('Calculated as: balance_transaction->amount (NET) + balance_transaction->fee = GROSS.');
+        $this->line('');
+        $this->info('Stripe balance reconciliation (EUR):');
+        $this->info(' - Gross collected: €' . number_format($balanceSummary['cash_gross_collected_eur'], 2));
+        $this->info(' - Refunds: €' . number_format($balanceSummary['cash_refunds_eur'], 2));
+        $this->info(' - Chargebacks: €' . number_format($balanceSummary['cash_chargebacks_eur'], 2));
+        $this->info(' - Stripe fees: €' . number_format($balanceSummary['cash_stripe_fees_eur'], 2));
+        $this->info(' - Adjustments / disputes: €' . number_format($balanceSummary['cash_adjustments_eur'], 2));
+        $this->info(' - Net movement: €' . number_format($balanceSummary['cash_net_movement_eur'], 2));
+        $this->info(' - Payouts: €' . number_format($balanceSummary['payouts_eur'], 2));
 
         return Command::SUCCESS;
     }
@@ -163,17 +186,29 @@ class GenerateTaxExport extends Command
         $aggregatedReport = [];
         foreach ($invoices as $invoice) {
             $country = $invoice['cust_country'];
-            $customerType = is_null($invoice['cust_vat_id']) && $this->isEuropeanCountry($country) ? 'individual' : 'business';
+            $customerType = $invoice['customer_type'] ?? (is_null($invoice['cust_vat_id']) && $this->isEuropeanCountry($country) ? 'individual' : 'business');
             if (! isset($aggregatedReport[$country])) {
                 $defaultVal = [
                     'count' => 0,
+                    'gross_total_usd' => 0,
+                    'refund_amount_usd' => 0,
+                    'credit_notes_amount_usd' => 0,
+                    'chargeback_amount_usd' => 0,
                     'total_usd' => 0,
                     'tax_total_usd' => 0,
                     'total_after_tax_usd' => 0,
+                    'dispute_amount_usd' => 0,
+                    'gross_total_eur' => 0,
+                    'refund_amount_eur' => 0,
+                    'credit_notes_amount_eur' => 0,
+                    'chargeback_amount_eur' => 0,
+                    'cash_basis_before_adjustments_eur' => 0,
                     'total_eur' => 0,
                     'tax_total_eur' => 0,
                     'total_after_tax_eur' => 0,
                     'stripe_fee_eur' => 0,
+                    'net_after_stripe_fees_eur' => 0,
+                    'dispute_amount_eur' => 0,
                 ];
                 $aggregatedReport[$country] = [
                     'individual' => $defaultVal,
@@ -181,13 +216,25 @@ class GenerateTaxExport extends Command
                 ];
             }
             $aggregatedReport[$country][$customerType]['count']++;
+            $aggregatedReport[$country][$customerType]['gross_total_usd'] = ($aggregatedReport[$country][$customerType]['gross_total_usd'] ?? 0) + ($invoice['gross_total_usd'] ?? 0);
+            $aggregatedReport[$country][$customerType]['refund_amount_usd'] = ($aggregatedReport[$country][$customerType]['refund_amount_usd'] ?? 0) + ($invoice['refund_amount_usd'] ?? 0);
+            $aggregatedReport[$country][$customerType]['credit_notes_amount_usd'] = ($aggregatedReport[$country][$customerType]['credit_notes_amount_usd'] ?? 0) + ($invoice['credit_notes_amount_usd'] ?? 0);
+            $aggregatedReport[$country][$customerType]['chargeback_amount_usd'] = ($aggregatedReport[$country][$customerType]['chargeback_amount_usd'] ?? 0) + ($invoice['chargeback_amount_usd'] ?? 0);
             $aggregatedReport[$country][$customerType]['total_usd'] = ($aggregatedReport[$country][$customerType]['total_usd'] ?? 0) + $invoice['total_usd'];
             $aggregatedReport[$country][$customerType]['tax_total_usd'] = ($aggregatedReport[$country][$customerType]['tax_total_usd'] ?? 0) + $invoice['tax_total_usd'];
             $aggregatedReport[$country][$customerType]['total_after_tax_usd'] = ($aggregatedReport[$country][$customerType]['total_after_tax_usd'] ?? 0) + $invoice['total_after_tax_usd'];
+            $aggregatedReport[$country][$customerType]['dispute_amount_usd'] = ($aggregatedReport[$country][$customerType]['dispute_amount_usd'] ?? 0) + ($invoice['dispute_amount_usd'] ?? 0);
+            $aggregatedReport[$country][$customerType]['gross_total_eur'] = ($aggregatedReport[$country][$customerType]['gross_total_eur'] ?? 0) + ($invoice['gross_total_eur'] ?? 0);
+            $aggregatedReport[$country][$customerType]['refund_amount_eur'] = ($aggregatedReport[$country][$customerType]['refund_amount_eur'] ?? 0) + ($invoice['refund_amount_eur'] ?? 0);
+            $aggregatedReport[$country][$customerType]['credit_notes_amount_eur'] = ($aggregatedReport[$country][$customerType]['credit_notes_amount_eur'] ?? 0) + ($invoice['credit_notes_amount_eur'] ?? 0);
+            $aggregatedReport[$country][$customerType]['chargeback_amount_eur'] = ($aggregatedReport[$country][$customerType]['chargeback_amount_eur'] ?? 0) + ($invoice['chargeback_amount_eur'] ?? 0);
+            $aggregatedReport[$country][$customerType]['cash_basis_before_adjustments_eur'] = ($aggregatedReport[$country][$customerType]['cash_basis_before_adjustments_eur'] ?? 0) + ($invoice['cash_basis_before_adjustments_eur'] ?? 0);
             $aggregatedReport[$country][$customerType]['stripe_fee_eur'] = ($aggregatedReport[$country][$customerType]['stripe_fee_eur'] ?? 0) + $invoice['stripe_fee_eur'];
             $aggregatedReport[$country][$customerType]['total_eur'] = ($aggregatedReport[$country][$customerType]['total_eur'] ?? 0) + $invoice['total_eur'];
             $aggregatedReport[$country][$customerType]['tax_total_eur'] = ($aggregatedReport[$country][$customerType]['tax_total_eur'] ?? 0) + $invoice['tax_total_eur'];
             $aggregatedReport[$country][$customerType]['total_after_tax_eur'] = ($aggregatedReport[$country][$customerType]['total_after_tax_eur'] ?? 0) + $invoice['total_after_tax_eur'];
+            $aggregatedReport[$country][$customerType]['net_after_stripe_fees_eur'] = ($aggregatedReport[$country][$customerType]['net_after_stripe_fees_eur'] ?? 0) + ($invoice['net_after_stripe_fees_eur'] ?? 0);
+            $aggregatedReport[$country][$customerType]['dispute_amount_eur'] = ($aggregatedReport[$country][$customerType]['dispute_amount_eur'] ?? 0) + ($invoice['dispute_amount_eur'] ?? 0);
         }
 
         $finalReport = [];
@@ -395,85 +442,61 @@ class GenerateTaxExport extends Command
         return (int) round($grossAmount * ($partialAmount / $originalAmount));
     }
 
-    private function getBalanceTransactionSummary(string $startDate, string $endDate): array
+    private function resolveBalanceSummary(
+        string $startDate,
+        string $endDate,
+        ?string $datasetId,
+        array $metadata,
+        StripeExportDatasetStore $store,
+        StripeBalanceSummaryService $balanceSummaryService
+    ): array
     {
-        $queryOptions = [
-            'limit' => 100,
-            'created' => [
-                'gte' => Carbon::parse($startDate)->startOfDay()->timestamp,
-                'lte' => Carbon::parse($endDate)->endOfDay()->timestamp,
-            ],
-        ];
+        if (!$datasetId) {
+            return $balanceSummaryService->summarize($startDate, $endDate);
+        }
 
-        $transactions = Cashier::stripe()->balanceTransactions->all($queryOptions);
-        $rows = [];
+        $existing = $metadata['balance_summary'] ?? null;
+        if (is_array($existing) && !empty($existing)) {
+            return $balanceSummaryService->aggregate([$existing]);
+        }
 
-        do {
-            foreach ($transactions as $transaction) {
-                $rows[] = $transaction;
-            }
-
-            if (empty($transactions->data) || !$transactions->has_more) {
-                break;
-            }
-
-            $queryOptions['starting_after'] = end($transactions->data)->id;
-            $transactions = Cashier::stripe()->balanceTransactions->all($queryOptions);
-        } while (true);
-
-        $grossCollected = 0;
-        $refunds = 0;
-        $stripeFees = 0;
-        $adjustments = 0;
-        $netMovement = 0;
-        $payouts = 0;
-
-        foreach ($rows as $transaction) {
-            $type = $transaction->type ?? '';
-            $amount = (int) ($transaction->amount ?? 0);
-            $fee = (int) ($transaction->fee ?? 0);
-            $net = (int) ($transaction->net ?? 0);
-
-            if (in_array($type, ['charge', 'payment'], true)) {
-                $grossCollected += max(0, $amount);
-                $stripeFees += $fee;
-                $netMovement += $net;
-                continue;
-            }
-
-            if (in_array($type, ['refund', 'payment_refund'], true)) {
-                $refunds += abs($amount);
-                $stripeFees += $fee;
-                $netMovement += $net;
-                continue;
-            }
-
-            if ($type === 'stripe_fee') {
-                $stripeFees += abs($amount);
-                $netMovement += $net;
-                continue;
-            }
-
-            if ($type === 'adjustment') {
-                $adjustments += $net;
-                $stripeFees += $fee;
-                $netMovement += $net;
-                continue;
-            }
-
-            if ($type === 'payout') {
-                $payouts += abs($amount);
+        $chunkSummaries = [];
+        foreach (($metadata['chunks'] ?? []) as $chunk) {
+            $chunkSummary = $chunk['balance_summary'] ?? null;
+            if (is_array($chunkSummary) && !empty($chunkSummary)) {
+                $chunkSummaries[] = $chunkSummary;
             }
         }
 
-        return [
-            'cash_gross_collected_eur' => $grossCollected / 100,
-            'cash_refunds_eur' => $refunds / 100,
-            'cash_stripe_fees_eur' => $stripeFees / 100,
-            'cash_adjustments_eur' => $adjustments / 100,
-            'cash_net_movement_eur' => $netMovement / 100,
-            'payouts_eur' => $payouts / 100,
-        ];
+        if (!empty($chunkSummaries)) {
+            $summary = $balanceSummaryService->aggregate($chunkSummaries);
+            $store->updateMetadata($datasetId, ['balance_summary' => $summary]);
+
+            return $summary;
+        }
+
+        $this->warn('Dataset balance summary missing. Recomputing monthly reconciliation from Stripe...');
+
+        $recomputedChunkSummaries = [];
+        foreach (($metadata['chunks'] ?? []) as $chunk) {
+            $chunkKey = (string) ($chunk['chunk_key'] ?? '');
+            [$chunkStartDate, $chunkEndDate] = explode('_', $chunkKey) + [null, null];
+            if (!$chunkStartDate || !$chunkEndDate) {
+                continue;
+            }
+
+            $this->line("Reconciliation chunk {$chunkStartDate} -> {$chunkEndDate}");
+            $recomputedChunkSummaries[] = $balanceSummaryService->summarize($chunkStartDate, $chunkEndDate);
+        }
+
+        if (!empty($recomputedChunkSummaries)) {
+            $summary = $balanceSummaryService->aggregate($recomputedChunkSummaries);
+            $store->updateMetadata($datasetId, ['balance_summary' => $summary]);
+
+            return $summary;
+        }
+
+        return $balanceSummaryService->summarize($startDate, $endDate);
     }
 
     private function appendReconciliationRows(array $aggregatedReport, array $summary): array
@@ -481,6 +504,7 @@ class GenerateTaxExport extends Command
         foreach ([
             'cash_gross_collected' => 'cash_gross_collected_eur',
             'cash_refunds' => 'cash_refunds_eur',
+            'cash_chargebacks' => 'cash_chargebacks_eur',
             'cash_stripe_fees' => 'cash_stripe_fees_eur',
             'cash_adjustments' => 'cash_adjustments_eur',
             'cash_net_movement' => 'cash_net_movement_eur',
@@ -493,18 +517,20 @@ class GenerateTaxExport extends Command
                 'gross_total_usd' => 0,
                 'refund_amount_usd' => 0,
                 'credit_notes_amount_usd' => 0,
-                'ca_net_usd' => 0,
+                'chargeback_amount_usd' => 0,
                 'total_usd' => 0,
                 'tax_total_usd' => 0,
                 'total_after_tax_usd' => 0,
                 'gross_total_eur' => 0,
                 'refund_amount_eur' => 0,
                 'credit_notes_amount_eur' => 0,
-                'ca_net_eur' => 0,
+                'chargeback_amount_eur' => 0,
+                'cash_basis_before_adjustments_eur' => 0,
                 'stripe_fee_eur' => 0,
-                'ca_net_after_stripe_fees_eur' => 0,
+                'net_after_stripe_fees_eur' => 0,
                 'cash_gross_collected_eur' => 0,
                 'cash_refunds_eur' => 0,
+                'cash_chargebacks_eur' => 0,
                 'cash_stripe_fees_eur' => 0,
                 'cash_adjustments_eur' => 0,
                 'cash_net_movement_eur' => 0,

--- a/api/app/Console/Commands/Tax/GenerateTaxExport.php
+++ b/api/app/Console/Commands/Tax/GenerateTaxExport.php
@@ -69,8 +69,7 @@ class GenerateTaxExport extends Command
         StripeExportDatasetService $collector,
         StripeExportDatasetStore $store,
         StripeBalanceSummaryService $balanceSummaryService
-    )
-    {
+    ) {
         // Start the processing timer
         $startTime = microtime(true);
 
@@ -449,8 +448,7 @@ class GenerateTaxExport extends Command
         array $metadata,
         StripeExportDatasetStore $store,
         StripeBalanceSummaryService $balanceSummaryService
-    ): array
-    {
+    ): array {
         if (!$datasetId) {
             return $balanceSummaryService->summarize($startDate, $endDate);
         }

--- a/api/app/Exports/Tax/ArrayExport.php
+++ b/api/app/Exports/Tax/ArrayExport.php
@@ -10,17 +10,35 @@ class ArrayExport implements FromArray, WithHeadings
 {
     use Exportable;
 
+    private array $headingsList;
+
     public function __construct(public array $data)
     {
+        $this->headingsList = [];
+
+        foreach ($this->data as $row) {
+            foreach (array_keys($row) as $key) {
+                if (!in_array($key, $this->headingsList, true)) {
+                    $this->headingsList[] = $key;
+                }
+            }
+        }
     }
 
     public function array(): array
     {
-        return $this->data;
+        return array_map(function (array $row) {
+            $normalized = [];
+            foreach ($this->headingsList as $heading) {
+                $normalized[$heading] = $row[$heading] ?? null;
+            }
+
+            return $normalized;
+        }, $this->data);
     }
 
     public function headings(): array
     {
-        return array_keys($this->data[0]);
+        return $this->headingsList;
     }
 }

--- a/api/app/Services/Tax/StripeBalanceSummaryService.php
+++ b/api/app/Services/Tax/StripeBalanceSummaryService.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Services\Tax;
+
+use Carbon\Carbon;
+use Laravel\Cashier\Cashier;
+
+class StripeBalanceSummaryService
+{
+    public function summarize(string $startDate, string $endDate): array
+    {
+        $queryOptions = [
+            'limit' => 100,
+            'expand' => ['data.source'],
+            'created' => [
+                'gte' => Carbon::parse($startDate)->startOfDay()->timestamp,
+                'lte' => Carbon::parse($endDate)->endOfDay()->timestamp,
+            ],
+        ];
+
+        $rows = [];
+        $transactions = Cashier::stripe()->balanceTransactions->all($queryOptions);
+
+        do {
+            foreach ($transactions as $transaction) {
+                if (($transaction->currency ?? null) !== 'eur') {
+                    continue;
+                }
+
+                $rows[] = $transaction;
+            }
+
+            if (empty($transactions->data) || !$transactions->has_more) {
+                break;
+            }
+
+            $queryOptions['starting_after'] = end($transactions->data)->id;
+            $transactions = Cashier::stripe()->balanceTransactions->all($queryOptions);
+        } while (true);
+
+        $summary = $this->emptySummary();
+
+        foreach ($rows as $transaction) {
+            $type = $transaction->type ?? '';
+            $amount = (int) ($transaction->amount ?? 0);
+            $fee = (int) ($transaction->fee ?? 0);
+            $net = (int) ($transaction->net ?? 0);
+
+            if (in_array($type, ['charge', 'payment'], true)) {
+                $summary['cash_gross_collected_eur'] += max(0, $amount) / 100;
+                $summary['cash_stripe_fees_eur'] += $fee / 100;
+                $summary['cash_net_movement_eur'] += $net / 100;
+                continue;
+            }
+
+            if (in_array($type, ['refund', 'payment_refund'], true)) {
+                $summary['cash_refunds_eur'] += abs($amount) / 100;
+                $summary['cash_stripe_fees_eur'] += $fee / 100;
+                $summary['cash_net_movement_eur'] += $net / 100;
+                continue;
+            }
+
+            if ($this->isChargebackTransaction($transaction)) {
+                $summary['cash_chargebacks_eur'] += abs($amount) / 100;
+                $summary['cash_stripe_fees_eur'] += $fee / 100;
+                $summary['cash_net_movement_eur'] += $net / 100;
+                continue;
+            }
+
+            if ($type === 'stripe_fee') {
+                $summary['cash_stripe_fees_eur'] += abs($amount) / 100;
+                $summary['cash_net_movement_eur'] += $net / 100;
+                continue;
+            }
+
+            if ($type === 'adjustment') {
+                $summary['cash_adjustments_eur'] += $net / 100;
+                $summary['cash_stripe_fees_eur'] += $fee / 100;
+                $summary['cash_net_movement_eur'] += $net / 100;
+                continue;
+            }
+
+            if ($type === 'payout') {
+                $summary['payouts_eur'] += abs($amount) / 100;
+            }
+        }
+
+        return $summary;
+    }
+
+    public function aggregate(array $summaries): array
+    {
+        $aggregate = $this->emptySummary();
+
+        foreach ($summaries as $summary) {
+            foreach ($aggregate as $key => $value) {
+                $aggregate[$key] += (float) ($summary[$key] ?? 0);
+            }
+        }
+
+        return $aggregate;
+    }
+
+    public function emptySummary(): array
+    {
+        return [
+            'cash_gross_collected_eur' => 0.0,
+            'cash_refunds_eur' => 0.0,
+            'cash_chargebacks_eur' => 0.0,
+            'cash_stripe_fees_eur' => 0.0,
+            'cash_adjustments_eur' => 0.0,
+            'cash_net_movement_eur' => 0.0,
+            'payouts_eur' => 0.0,
+        ];
+    }
+
+    private function isChargebackTransaction(object $transaction): bool
+    {
+        $type = $transaction->type ?? '';
+        if (in_array($type, ['issuing_dispute', 'payment_reversal'], true)) {
+            return true;
+        }
+
+        $source = $transaction->source ?? null;
+        if (($source->object ?? null) === 'dispute') {
+            return true;
+        }
+
+        $description = strtolower((string) ($transaction->description ?? ''));
+
+        return $type === 'adjustment' && (str_contains($description, 'dispute') || str_contains($description, 'chargeback'));
+    }
+}

--- a/api/app/Services/Tax/StripeCashReconciliationService.php
+++ b/api/app/Services/Tax/StripeCashReconciliationService.php
@@ -1,0 +1,265 @@
+<?php
+
+namespace App\Services\Tax;
+
+use Carbon\Carbon;
+use Laravel\Cashier\Cashier;
+
+class StripeCashReconciliationService
+{
+    public function buildExportRows(string $startDate, string $endDate, array $invoiceIndex = []): array
+    {
+        $transactions = $this->fetchTransactions($startDate, $endDate);
+        $summary = [];
+        $detailRows = [];
+
+        foreach ($transactions as $transaction) {
+            $detailRow = $this->mapTransaction($transaction, $invoiceIndex);
+            $detailRows[] = $detailRow;
+
+            $bucket = $detailRow['bucket'];
+            if (!isset($summary[$bucket])) {
+                $summary[$bucket] = [
+                    'label' => $detailRow['category'],
+                    'transaction_count' => 0,
+                    'amount_abs_eur' => 0.0,
+                    'fee_eur' => 0.0,
+                    'net_eur' => 0.0,
+                ];
+            }
+
+            $summary[$bucket]['transaction_count']++;
+            $summary[$bucket]['amount_abs_eur'] += (float) ($detailRow['amount_abs_eur'] ?? 0);
+            $summary[$bucket]['fee_eur'] += (float) ($detailRow['fee_eur'] ?? 0);
+            $summary[$bucket]['net_eur'] += (float) ($detailRow['net_eur'] ?? 0);
+        }
+
+        $rows = [];
+        foreach ([
+            'charges',
+            'refunds',
+            'chargebacks',
+            'additional_fees',
+            'reserve_holds',
+            'reserve_releases',
+            'adjustments',
+            'payouts',
+            'other',
+        ] as $bucket) {
+            if (!isset($summary[$bucket])) {
+                continue;
+            }
+
+            $rows[] = [
+                'section' => 'summary',
+                'category' => $summary[$bucket]['label'],
+                'bucket' => $bucket,
+                'transaction_count' => $summary[$bucket]['transaction_count'],
+                'amount_abs_eur' => round($summary[$bucket]['amount_abs_eur'], 2),
+                'fee_eur' => round($summary[$bucket]['fee_eur'], 2),
+                'net_eur' => round($summary[$bucket]['net_eur'], 2),
+            ];
+        }
+
+        $rows[] = [
+            'section' => 'summary',
+            'category' => 'Net activity (excluding payouts)',
+            'bucket' => 'net_activity',
+            'transaction_count' => '',
+            'amount_abs_eur' => '',
+            'fee_eur' => '',
+            'net_eur' => round(array_sum(array_map(
+                fn (array $row) => $row['bucket'] === 'payouts' ? 0 : (float) ($row['net_eur'] ?? 0),
+                $detailRows
+            )), 2),
+        ];
+
+        $rows[] = [];
+
+        foreach ($detailRows as $detailRow) {
+            $rows[] = $detailRow;
+        }
+
+        return $rows;
+    }
+
+    private function fetchTransactions(string $startDate, string $endDate): array
+    {
+        $queryOptions = [
+            'limit' => 100,
+            'created' => [
+                'gte' => Carbon::parse($startDate)->startOfDay()->timestamp,
+                'lte' => Carbon::parse($endDate)->endOfDay()->timestamp,
+            ],
+        ];
+
+        $rows = [];
+        $transactions = Cashier::stripe()->balanceTransactions->all($queryOptions);
+
+        do {
+            foreach ($transactions as $transaction) {
+                if (($transaction->currency ?? null) !== 'eur') {
+                    continue;
+                }
+
+                $rows[] = $transaction;
+            }
+
+            if (empty($transactions->data) || !$transactions->has_more) {
+                break;
+            }
+
+            $queryOptions['starting_after'] = end($transactions->data)->id;
+            $transactions = Cashier::stripe()->balanceTransactions->all($queryOptions);
+        } while (true);
+
+        return $rows;
+    }
+
+    private function mapTransaction(object $transaction, array $invoiceIndex): array
+    {
+        [$bucket, $label] = $this->classifyTransaction($transaction);
+
+        $source = $transaction->source ?? null;
+        $sourceObject = is_object($source) ? ($source->object ?? null) : null;
+        $sourceId = is_string($source) ? $source : ($source->id ?? null);
+        $chargeId = null;
+        $invoiceId = null;
+        $paymentIntentId = null;
+
+        if ($sourceObject === 'charge') {
+            $chargeId = $source->id ?? null;
+            $invoiceId = $source->invoice ?? null;
+            $paymentIntentId = $source->payment_intent ?? null;
+        } elseif ($sourceObject === 'refund') {
+            $chargeId = $source->charge ?? null;
+            $paymentIntentId = $source->payment_intent ?? null;
+        } elseif ($sourceObject === 'dispute') {
+            $chargeId = $source->charge ?? null;
+            $paymentIntentId = $source->payment_intent ?? null;
+        } elseif ($sourceObject === 'payout') {
+            $sourceId = $source->id ?? $sourceId;
+        }
+
+        if (!$chargeId && in_array($transaction->type ?? '', ['charge', 'payment'], true) && is_string($sourceId)) {
+            $chargeId = $sourceId;
+        }
+
+        $invoiceRow = $this->resolveInvoiceRow($invoiceIndex, $invoiceId, $chargeId, $paymentIntentId);
+        $amount = (int) ($transaction->amount ?? 0) / 100;
+        $fee = (int) ($transaction->fee ?? 0) / 100;
+        $net = (int) ($transaction->net ?? 0) / 100;
+
+        return [
+            'section' => 'transaction',
+            'category' => $label,
+            'bucket' => $bucket,
+            'created_at' => Carbon::createFromTimestamp((int) $transaction->created)->format('Y-m-d H:i:s'),
+            'available_on' => isset($transaction->available_on)
+                ? Carbon::createFromTimestamp((int) $transaction->available_on)->format('Y-m-d')
+                : null,
+            'transaction_id' => $transaction->id ?? null,
+            'transaction_type' => $transaction->type ?? null,
+            'reporting_category' => $transaction->reporting_category ?? null,
+            'description' => $transaction->description ?? null,
+            'source_object' => $sourceObject,
+            'source_id' => $sourceId,
+            'charge_id' => $chargeId,
+            'payment_intent_id' => $paymentIntentId,
+            'invoice_id' => $invoiceId,
+            'amount_eur' => round($amount, 2),
+            'amount_abs_eur' => round(abs($amount), 2),
+            'fee_eur' => round($fee, 2),
+            'net_eur' => round($net, 2),
+            'invoice_accounting_at' => $invoiceRow['accounting_at'] ?? null,
+            'invoice_created_at' => $invoiceRow['created_at'] ?? null,
+            'invoice_country' => $invoiceRow['cust_country'] ?? null,
+            'invoice_customer_type' => $invoiceRow['customer_type'] ?? null,
+            'invoice_gross_total_eur' => $invoiceRow['gross_total_eur'] ?? null,
+            'invoice_total_eur' => $invoiceRow['total_eur'] ?? null,
+            'invoice_stripe_fee_eur' => $invoiceRow['stripe_fee_eur'] ?? null,
+        ];
+    }
+
+    private function resolveInvoiceRow(array $invoiceIndex, ?string $invoiceId, ?string $chargeId, ?string $paymentIntentId): ?array
+    {
+        if ($invoiceId && isset($invoiceIndex['by_invoice_id'][$invoiceId])) {
+            return $invoiceIndex['by_invoice_id'][$invoiceId];
+        }
+
+        if ($chargeId && isset($invoiceIndex['by_charge_id'][$chargeId])) {
+            return $invoiceIndex['by_charge_id'][$chargeId];
+        }
+
+        if ($paymentIntentId && isset($invoiceIndex['by_payment_intent_id'][$paymentIntentId])) {
+            return $invoiceIndex['by_payment_intent_id'][$paymentIntentId];
+        }
+
+        return null;
+    }
+
+    private function classifyTransaction(object $transaction): array
+    {
+        $type = $transaction->type ?? '';
+        $description = strtolower((string) ($transaction->description ?? ''));
+
+        if (in_array($type, ['charge', 'payment'], true)) {
+            return ['charges', 'Charges'];
+        }
+
+        if (in_array($type, ['refund', 'payment_refund'], true)) {
+            return ['refunds', 'Refunds'];
+        }
+
+        if ($this->isChargebackTransaction($transaction)) {
+            return ['chargebacks', 'Chargebacks'];
+        }
+
+        if ($type === 'stripe_fee') {
+            return ['additional_fees', 'Additional Stripe fees'];
+        }
+
+        if ($type === 'payout_minimum_balance_hold') {
+            return ['reserve_holds', 'Payout minimum balance hold'];
+        }
+
+        if ($type === 'payout_minimum_balance_release') {
+            return ['reserve_releases', 'Payout minimum balance release'];
+        }
+
+        if ($type === 'adjustment' && str_contains($description, 'payout minimum balance hold')) {
+            return ['reserve_holds', 'Payout minimum balance hold'];
+        }
+
+        if ($type === 'adjustment' && str_contains($description, 'payout minimum balance release')) {
+            return ['reserve_releases', 'Payout minimum balance release'];
+        }
+
+        if ($type === 'adjustment') {
+            return ['adjustments', 'Adjustments'];
+        }
+
+        if ($type === 'payout') {
+            return ['payouts', 'Payouts'];
+        }
+
+        return ['other', 'Other'];
+    }
+
+    private function isChargebackTransaction(object $transaction): bool
+    {
+        $type = $transaction->type ?? '';
+        if (in_array($type, ['issuing_dispute', 'payment_reversal'], true)) {
+            return true;
+        }
+
+        $source = $transaction->source ?? null;
+        if (is_object($source) && ($source->object ?? null) === 'dispute') {
+            return true;
+        }
+
+        $description = strtolower((string) ($transaction->description ?? ''));
+
+        return $type === 'adjustment' && (str_contains($description, 'dispute') || str_contains($description, 'chargeback'));
+    }
+}

--- a/api/app/Services/Tax/StripeExportDatasetService.php
+++ b/api/app/Services/Tax/StripeExportDatasetService.php
@@ -8,6 +8,8 @@ use Stripe\Invoice;
 
 class StripeExportDatasetService
 {
+    private array $chargesByPaymentIntentId = [];
+
     public const EU_TAX_RATES = [
         'AT' => 20,
         'BE' => 21,
@@ -41,9 +43,11 @@ class StripeExportDatasetService
     public function collect(string $startDate, string $endDate, ?callable $onInvoiceProcessed = null): array
     {
         $processedInvoices = [];
+        $this->chargesByPaymentIntentId = $this->prefetchChargesByPaymentIntentId($startDate, $endDate);
         $stats = [
             'payment_not_successful_count' => 0,
             'refunded_invoices_count' => 0,
+            'disputed_invoices_count' => 0,
             'missing_data_invoices_count' => 0,
             'total_invoice' => 0,
             'processed_invoice_count' => 0,
@@ -53,22 +57,19 @@ class StripeExportDatasetService
         $queryOptions = [
             'limit' => 100,
             'expand' => [
-                'data.customer',
-                'data.customer.address',
-                'data.customer.tax_ids',
-                'data.payment_intent',
-                'data.payment_intent.payment_method',
-                'data.payment_intent.latest_charge.balance_transaction',
-                'data.charge.balance_transaction',
+                'data.status_transitions',
+                'data.payments',
                 'data.automatic_tax',
-                'data.total_tax_amounts.tax_rate',
             ],
             'status' => 'paid',
             'created' => [
-                'gte' => Carbon::parse($startDate)->startOfDay()->timestamp,
+                'gte' => Carbon::parse($startDate)->subDays($this->getAccountingLookbackDays())->startOfDay()->timestamp,
                 'lte' => Carbon::parse($endDate)->endOfDay()->timestamp,
             ],
         ];
+
+        $startTs = Carbon::parse($startDate)->startOfDay()->timestamp;
+        $endTs = Carbon::parse($endDate)->endOfDay()->timestamp;
 
         $invoices = Cashier::stripe()->invoices->all($queryOptions);
 
@@ -81,9 +82,7 @@ class StripeExportDatasetService
                 $stats['total_invoice']++;
 
                 $invoiceStatus = $invoice->status ?? null;
-                $paymentIntentStatus = $invoice->payment_intent->status ?? null;
-
-                if ($invoiceStatus !== 'paid' && $paymentIntentStatus !== 'succeeded') {
+                if ($invoiceStatus !== 'paid') {
                     $stats['payment_not_successful_count']++;
                     continue;
                 }
@@ -91,13 +90,18 @@ class StripeExportDatasetService
                 $netInvoiceAmount = $this->getNetInvoiceAmount($invoice);
                 if (($invoice->total ?? 0) > 0 && $netInvoiceAmount <= 0) {
                     $stats['refunded_invoices_count']++;
-                    continue;
                 }
 
                 try {
                     $row = $this->formatDatasetRow($invoice);
+                    if (($row['accounting_ts'] ?? 0) < $startTs || ($row['accounting_ts'] ?? 0) > $endTs) {
+                        continue;
+                    }
                     if (($row['_defaulted_to_fr'] ?? false) === true) {
                         $stats['defaulted_to_fr_count']++;
+                    }
+                    if (($row['dispute_amount_usd'] ?? 0) > 0) {
+                        $stats['disputed_invoices_count']++;
                     }
                     $processedInvoices[] = $row;
                     $stats['processed_invoice_count']++;
@@ -126,21 +130,40 @@ class StripeExportDatasetService
 
     public function toTaxExportRow(array $row): array
     {
+        $grossTotalEur = (float) ($row['gross_total_eur'] ?? $row['total_eur']);
+        $stripeFeeEur = (float) ($row['stripe_fee_eur'] ?? 0);
+        $totalEur = (float) ($row['total_eur'] ?? 0);
+
         return [
             'invoice_id' => $row['invoice_id'],
+            'charge_id' => $row['charge_id'] ?? null,
+            'payment_intent_id' => $row['payment_intent_id'] ?? null,
             'created_at' => $row['created_at'],
+            'accounting_at' => $row['accounting_at'] ?? $row['created_at'],
             'cust_id' => $row['cust_id'],
             'cust_vat_id' => $row['cust_vat_id'],
             'cust_country' => $row['cust_country'],
             'tax_rate' => $row['tax_rate'],
             'customer_type' => $row['customer_type'],
+            'gross_total_usd' => $row['gross_total_usd'] ?? $row['total_usd'],
+            'refund_amount_usd' => $row['refund_amount_usd'] ?? 0,
+            'credit_notes_amount_usd' => $row['credit_notes_amount_usd'] ?? 0,
+            'chargeback_amount_usd' => $row['dispute_amount_usd'] ?? 0,
             'total_usd' => $row['total_usd'],
             'tax_total_usd' => $row['tax_total_usd'],
             'total_after_tax_usd' => $row['total_after_tax_usd'],
+            'dispute_amount_usd' => $row['dispute_amount_usd'] ?? 0,
+            'gross_total_eur' => $row['gross_total_eur'] ?? $row['total_eur'],
+            'refund_amount_eur' => $row['refund_amount_eur'] ?? 0,
+            'credit_notes_amount_eur' => $row['credit_notes_amount_eur'] ?? 0,
+            'chargeback_amount_eur' => $row['dispute_amount_eur'] ?? 0,
+            'cash_basis_before_adjustments_eur' => round($grossTotalEur - (float) ($row['refund_amount_eur'] ?? 0) - (float) ($row['dispute_amount_eur'] ?? 0), 2),
             'total_eur' => $row['total_eur'],
             'tax_total_eur' => $row['tax_total_eur'],
             'total_after_tax_eur' => $row['total_after_tax_eur'],
             'stripe_fee_eur' => $row['stripe_fee_eur'],
+            'net_after_stripe_fees_eur' => round($totalEur - $stripeFeeEur, 2),
+            'dispute_amount_eur' => $row['dispute_amount_eur'] ?? 0,
         ];
     }
 
@@ -151,33 +174,60 @@ class StripeExportDatasetService
         $cleanVatId = $vatId ? $this->cleanVatNumber($vatId) : null;
         $taxRate = $this->computeTaxRate($country, $cleanVatId);
 
+        $grossAmountUsd = (int) ($invoice->total ?? 0);
+        $refundAmountUsd = $this->getInvoiceRefundAmount($invoice);
+        $creditNotesAmountUsd = $this->getInvoiceCreditNotesAmount($invoice);
+        $cashRefundAmountUsd = max(0, $refundAmountUsd - $creditNotesAmountUsd);
         $caNetUsd = $this->getNetInvoiceAmount($invoice);
-        $taxAmountCollectedUsd = $taxRate > 0 ? $caNetUsd * $taxRate / ($taxRate + 100) : 0;
+        $originalTaxAmountUsd = $this->getInvoiceTaxAmount($invoice);
+        $taxAmountCollectedUsd = $this->applyPartialInvoiceAdjustments($invoice, $originalTaxAmountUsd);
 
         [$grossAmountEur, $stripeFeeEur] = $this->resolveGrossAmountAndFeeEur($invoice);
-        $caNetEur = $this->applyInvoiceAdjustmentsToGrossAmount($invoice, $grossAmountEur);
-        $taxAmountCollectedEur = $taxRate > 0 ? $caNetEur * $taxRate / ($taxRate + 100) : 0;
+        $refundAmountEur = $this->getInvoiceRefundAmountEur($invoice, $grossAmountEur);
+        $creditNotesAmountEur = $this->applyPartialInvoiceAdjustmentsToGrossAmount($invoice, $grossAmountEur, $creditNotesAmountUsd);
+        $disputeAmountEur = $this->getInvoiceDisputeAmountEur($invoice, $grossAmountEur);
+        $caNetEur = (int) max(0, round($grossAmountEur - $refundAmountEur - $creditNotesAmountEur - $disputeAmountEur));
+        $taxAmountCollectedEur = $this->applyPartialInvoiceAdjustmentsToGrossAmount($invoice, $grossAmountEur, $originalTaxAmountUsd);
+        $disputeAmountUsd = $this->getInvoiceDisputeAmount($invoice);
+        $effectiveStripeFeeEur = $this->getInvoiceEffectiveStripeFeeEur($invoice, $stripeFeeEur);
 
-        $customerType = is_null($cleanVatId) && $this->isEuropeanCountry($country) ? 'individual' : 'business';
-        $desEligible = $this->isEligibleForDes($country, $cleanVatId);
+        $hasEuVatId = $this->hasEuVatId($invoice, $country, $cleanVatId);
+        $customerType = !$hasEuVatId && $this->isEuropeanCountry($country) ? 'individual' : 'business';
+        $desEligible = $this->isEligibleForDes($country, $cleanVatId, $hasEuVatId);
+        $accountingTs = $this->resolveAccountingTimestamp($invoice);
         $createdAt = Carbon::createFromTimestamp($invoice->created);
+        $accountingAt = Carbon::createFromTimestamp($accountingTs);
+        $charge = $this->resolveInvoiceCharge($invoice);
+        $paymentIntentId = $this->extractPaymentIntentId($invoice);
 
         return [
             'invoice_id' => $invoice->id,
+            'charge_id' => $charge->id ?? null,
+            'payment_intent_id' => $paymentIntentId,
             'created_at' => $createdAt->format('Y-m-d H:i:s'),
             'created_ts' => $invoice->created,
+            'accounting_at' => $accountingAt->format('Y-m-d H:i:s'),
+            'accounting_ts' => $accountingTs,
             'cust_id' => $invoice->customer->id ?? 'unknown',
             'cust_vat_id' => $cleanVatId,
             'cust_country' => $country,
             'customer_type' => $customerType,
             'tax_rate' => $taxRate,
+            'gross_total_usd' => $grossAmountUsd / 100,
+            'refund_amount_usd' => $cashRefundAmountUsd / 100,
+            'credit_notes_amount_usd' => $creditNotesAmountUsd / 100,
             'total_usd' => $caNetUsd / 100,
             'tax_total_usd' => $taxAmountCollectedUsd / 100,
             'total_after_tax_usd' => ($caNetUsd - $taxAmountCollectedUsd) / 100,
+            'dispute_amount_usd' => $disputeAmountUsd / 100,
+            'gross_total_eur' => $grossAmountEur / 100,
+            'refund_amount_eur' => $refundAmountEur / 100,
+            'credit_notes_amount_eur' => $creditNotesAmountEur / 100,
             'total_eur' => $caNetEur / 100,
             'tax_total_eur' => $taxAmountCollectedEur / 100,
             'total_after_tax_eur' => ($caNetEur - $taxAmountCollectedEur) / 100,
-            'stripe_fee_eur' => $this->applyPartialInvoiceAdjustmentsToGrossAmount($invoice, $grossAmountEur, $stripeFeeEur) / 100,
+            'stripe_fee_eur' => $effectiveStripeFeeEur / 100,
+            'dispute_amount_eur' => $disputeAmountEur / 100,
             'des_eligible' => $desEligible,
             'des_country_code' => $country,
             'des_vat_number' => $cleanVatId,
@@ -186,10 +236,44 @@ class StripeExportDatasetService
         ];
     }
 
+    private function resolveAccountingTimestamp(Invoice $invoice): int
+    {
+        foreach (($invoice->payments->data ?? []) as $payment) {
+            $paidAt = $payment->status_transitions->paid_at ?? null;
+            if (is_numeric($paidAt) && (int) $paidAt > 0) {
+                return (int) $paidAt;
+            }
+        }
+
+        foreach ([
+            $invoice->effective_at ?? null,
+            $invoice->status_transitions->paid_at ?? null,
+            $invoice->status_transitions->finalized_at ?? null,
+            $invoice->created ?? null,
+        ] as $timestamp) {
+            if (is_numeric($timestamp) && (int) $timestamp > 0) {
+                return (int) $timestamp;
+            }
+        }
+
+        throw new \RuntimeException("Could not resolve accounting timestamp for invoice {$invoice->id}");
+    }
+
     private function resolveCountry(Invoice $invoice): array
     {
+        if (!empty($invoice->customer_address->country)) {
+            return [$invoice->customer_address->country, false];
+        }
+
         if (!empty($invoice->customer->address->country)) {
             return [$invoice->customer->address->country, false];
+        }
+
+        foreach (($invoice->total_taxes ?? []) as $taxAmount) {
+            $taxRateCountry = $taxAmount->tax_rate_details->country ?? null;
+            if (!empty($taxRateCountry)) {
+                return [$taxRateCountry, false];
+            }
         }
 
         foreach (($invoice->total_tax_amounts ?? []) as $taxAmount) {
@@ -204,15 +288,20 @@ class StripeExportDatasetService
             return [$autoTaxCountry, false];
         }
 
-        foreach (($invoice->customer->tax_ids->data ?? []) as $taxId) {
+        foreach ($this->getCustomerTaxIds($invoice) as $taxId) {
             if (!empty($taxId->country)) {
                 return [$taxId->country, false];
             }
         }
 
-        $paymentCountry = $invoice->payment_intent->payment_method->card->country ?? null;
-        if (!empty($paymentCountry)) {
-            return [$paymentCountry, false];
+        $charge = $this->resolveInvoiceCharge($invoice);
+        foreach ([
+            $charge->payment_method_details->card->country ?? null,
+            $charge->billing_details->address->country ?? null,
+        ] as $paymentCountry) {
+            if (!empty($paymentCountry)) {
+                return [$paymentCountry, false];
+            }
         }
 
         return ['FR', true];
@@ -220,44 +309,23 @@ class StripeExportDatasetService
 
     private function resolveGrossAmountAndFeeEur(Invoice $invoice): array
     {
+        if ((int) ($invoice->total ?? 0) <= 0) {
+            return [0, 0];
+        }
+
         if (isset($invoice->charge) && isset($invoice->charge->balance_transaction)) {
-            $netEur = $invoice->charge->balance_transaction->amount ?? 0;
+            $chargeAmountEur = $invoice->charge->balance_transaction->amount ?? 0;
             $feeEur = $invoice->charge->balance_transaction->fee ?? 0;
 
-            return [$netEur + $feeEur, $feeEur];
+            return [$chargeAmountEur, $feeEur];
         }
 
-        if (isset($invoice->payment_intent->latest_charge) && isset($invoice->payment_intent->latest_charge->balance_transaction)) {
-            $netEur = $invoice->payment_intent->latest_charge->balance_transaction->amount ?? 0;
-            $feeEur = $invoice->payment_intent->latest_charge->balance_transaction->fee ?? 0;
+        $charge = $this->resolveInvoiceCharge($invoice);
+        if ($charge && isset($charge->balance_transaction)) {
+            $chargeAmountEur = $charge->balance_transaction->amount ?? 0;
+            $feeEur = $charge->balance_transaction->fee ?? 0;
 
-            return [$netEur + $feeEur, $feeEur];
-        }
-
-        foreach (($invoice->payment_intent->charges->data ?? []) as $charge) {
-            if (isset($charge->balance_transaction)) {
-                $netEur = $charge->balance_transaction->amount ?? 0;
-                $feeEur = $charge->balance_transaction->fee ?? 0;
-
-                return [$netEur + $feeEur, $feeEur];
-            }
-        }
-
-        try {
-            $charges = Cashier::stripe()->charges->all([
-                'invoice' => $invoice->id,
-                'limit' => 1,
-                'expand' => ['data.balance_transaction'],
-            ]);
-
-            $charge = $charges->data[0] ?? null;
-            if ($charge && isset($charge->balance_transaction)) {
-                $netEur = $charge->balance_transaction->amount ?? 0;
-                $feeEur = $charge->balance_transaction->fee ?? 0;
-
-                return [$netEur + $feeEur, $feeEur];
-            }
-        } catch (\Throwable $e) {
+            return [$chargeAmountEur, $feeEur];
         }
 
         if (($invoice->currency ?? null) === 'eur') {
@@ -267,10 +335,70 @@ class StripeExportDatasetService
         throw new \RuntimeException("Could not resolve EUR amount for invoice {$invoice->id}");
     }
 
+    private function getInvoiceRefundAmountEur(Invoice $invoice, int $grossAmountEur): int
+    {
+        $charge = $this->resolveInvoiceCharge($invoice);
+        if (!$charge) {
+            return $this->applyPartialInvoiceAdjustmentsToGrossAmount($invoice, $grossAmountEur, max(0, $this->getInvoiceRefundAmount($invoice) - $this->getInvoiceCreditNotesAmount($invoice)));
+        }
+
+        $refundAmountEur = 0;
+        foreach (($charge->refunds->data ?? []) as $refund) {
+            $balanceTransaction = $refund->balance_transaction ?? null;
+            if (is_object($balanceTransaction) && isset($balanceTransaction->amount)) {
+                $refundAmountEur += abs((int) $balanceTransaction->amount);
+                continue;
+            }
+
+            if (($charge->amount ?? 0) > 0 && isset($refund->amount)) {
+                $refundAmountEur += (int) round($grossAmountEur * (((int) $refund->amount) / ((int) $charge->amount)));
+            }
+        }
+
+        if ($refundAmountEur > 0) {
+            return $refundAmountEur;
+        }
+
+        return $this->applyPartialInvoiceAdjustmentsToGrossAmount($invoice, $grossAmountEur, max(0, $this->getInvoiceRefundAmount($invoice) - $this->getInvoiceCreditNotesAmount($invoice)));
+    }
+
+    private function getInvoiceEffectiveStripeFeeEur(Invoice $invoice, int $chargeFeeEur): int
+    {
+        $charge = $this->resolveInvoiceCharge($invoice);
+        if (!$charge) {
+            return $chargeFeeEur;
+        }
+
+        $effectiveFeeEur = $chargeFeeEur;
+        foreach (($charge->refunds->data ?? []) as $refund) {
+            $balanceTransaction = $refund->balance_transaction ?? null;
+            if (is_object($balanceTransaction) && isset($balanceTransaction->fee)) {
+                $effectiveFeeEur += (int) $balanceTransaction->fee;
+            }
+        }
+
+        return $effectiveFeeEur;
+    }
+
+    private function getInvoiceDisputeAmountEur(Invoice $invoice, int $grossAmountEur): int
+    {
+        $charge = $this->resolveInvoiceCharge($invoice);
+        $disputeAmount = $this->getInvoiceDisputeAmount($invoice);
+        if (!$charge || $disputeAmount <= 0) {
+            return 0;
+        }
+
+        if (($charge->amount ?? 0) > 0) {
+            return (int) round($grossAmountEur * ($disputeAmount / ((int) $charge->amount)));
+        }
+
+        return $this->applyPartialInvoiceAdjustmentsToGrossAmount($invoice, $grossAmountEur, $disputeAmount);
+    }
+
     private function extractVatId(Invoice $invoice): ?string
     {
-        foreach (($invoice->customer->tax_ids->data ?? []) as $taxId) {
-            if (!empty($taxId->value)) {
+        foreach ($this->getCustomerTaxIds($invoice) as $taxId) {
+            if (($taxId->type ?? null) === 'eu_vat' && !empty($taxId->value)) {
                 return $taxId->value;
             }
         }
@@ -278,9 +406,29 @@ class StripeExportDatasetService
         return null;
     }
 
-    private function isEligibleForDes(?string $country, ?string $vatId): bool
+    private function hasEuVatId(Invoice $invoice, ?string $country, ?string $vatId): bool
     {
-        if (!$country || $country === 'FR' || !$this->isEuropeanCountry($country) || !$vatId) {
+        if (!$vatId || !$country) {
+            return false;
+        }
+
+        foreach ($this->getCustomerTaxIds($invoice) as $taxId) {
+            if (($taxId->type ?? null) !== 'eu_vat') {
+                continue;
+            }
+
+            $cleaned = $this->cleanVatNumber((string) ($taxId->value ?? ''));
+            if ($cleaned === $vatId && str_starts_with($cleaned, $country)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isEligibleForDes(?string $country, ?string $vatId, bool $hasEuVatId): bool
+    {
+        if (!$country || $country === 'FR' || !$this->isEuropeanCountry($country) || !$vatId || !$hasEuVatId) {
             return false;
         }
 
@@ -310,17 +458,68 @@ class StripeExportDatasetService
         return self::EU_TAX_RATES[$countryCode] ?? 0;
     }
 
+    private function getInvoiceTaxAmount(Invoice $invoice): int
+    {
+        if (isset($invoice->tax) && is_numeric($invoice->tax)) {
+            return (int) $invoice->tax;
+        }
+
+        if (isset($invoice->total_excluding_tax) && is_numeric($invoice->total_excluding_tax) && isset($invoice->total)) {
+            return max(0, (int) $invoice->total - (int) $invoice->total_excluding_tax);
+        }
+
+        $totalTaxes = $invoice->total_taxes ?? null;
+        if (is_iterable($totalTaxes)) {
+            $sum = 0;
+            foreach ($totalTaxes as $taxAmount) {
+                $sum += (int) ($taxAmount->amount ?? 0);
+            }
+
+            return $sum;
+        }
+
+        $totalTaxAmounts = $invoice->total_tax_amounts ?? null;
+        if (is_iterable($totalTaxAmounts)) {
+            $sum = 0;
+            foreach ($totalTaxAmounts as $taxAmount) {
+                $sum += (int) ($taxAmount->amount ?? 0);
+            }
+
+            return $sum;
+        }
+
+        return 0;
+    }
+
+    private function getInvoiceDisputeAmount(Invoice $invoice): int
+    {
+        $charge = $this->resolveInvoiceCharge($invoice);
+        if (!$charge || !($charge->disputed ?? false)) {
+            return 0;
+        }
+
+        $dispute = $charge->dispute ?? null;
+        $status = $dispute->status ?? null;
+        if ($status === 'won') {
+            return 0;
+        }
+
+        $amount = (int) ($dispute->amount ?? 0);
+        if ($amount > 0) {
+            return $amount;
+        }
+
+        return (int) ($charge->amount ?? 0);
+    }
+
     private function getInvoiceRefundAmount(Invoice $invoice): int
     {
         $invoiceRefundAmount = (int) ($invoice->amount_refunded ?? 0);
-        $chargeRefundAmount = 0;
+        $charge = $this->resolveInvoiceCharge($invoice);
+        $chargeRefundAmount = (int) ($charge->amount_refunded ?? 0);
 
-        if (isset($invoice->charge)) {
-            $chargeRefundAmount = (int) ($invoice->charge->amount_refunded ?? 0);
-
-            if ($chargeRefundAmount === 0 && isset($invoice->charge->refunded) && $invoice->charge->refunded) {
-                $chargeRefundAmount = (int) ($invoice->total ?? 0);
-            }
+        if ($chargeRefundAmount === 0 && isset($charge->refunded) && $charge->refunded) {
+            $chargeRefundAmount = (int) ($invoice->total ?? 0);
         }
 
         return max($invoiceRefundAmount, $chargeRefundAmount);
@@ -333,7 +532,23 @@ class StripeExportDatasetService
 
     private function getNetInvoiceAmount(Invoice $invoice): int
     {
-        return (int) (($invoice->total ?? 0) - $this->getInvoiceRefundAmount($invoice) - $this->getInvoiceCreditNotesAmount($invoice));
+        return (int) max(0, ($invoice->total ?? 0) - $this->getInvoiceRefundAmount($invoice) - $this->getInvoiceCreditNotesAmount($invoice) - $this->getInvoiceDisputeAmount($invoice));
+    }
+
+    private function applyPartialInvoiceAdjustments(Invoice $invoice, int|float $partialAmount): int
+    {
+        $originalAmount = (int) ($invoice->total ?? 0);
+        $netAmount = $this->getNetInvoiceAmount($invoice);
+
+        if ($originalAmount === 0 || $partialAmount == 0.0) {
+            return 0;
+        }
+
+        if ($netAmount === $originalAmount) {
+            return (int) round($partialAmount);
+        }
+
+        return (int) round($partialAmount * ($netAmount / $originalAmount));
     }
 
     private function applyInvoiceAdjustmentsToGrossAmount(Invoice $invoice, int|float $grossAmount): int
@@ -357,5 +572,119 @@ class StripeExportDatasetService
         }
 
         return (int) round($grossAmount * ($partialAmount / $originalAmount));
+    }
+
+    private function resolveInvoiceCharge(Invoice $invoice): ?object
+    {
+        if (isset($invoice->charge) && is_object($invoice->charge)) {
+            return $invoice->charge;
+        }
+
+        if (isset($invoice->payment_intent->latest_charge) && is_object($invoice->payment_intent->latest_charge)) {
+            return $invoice->payment_intent->latest_charge;
+        }
+
+        foreach (($invoice->payment_intent->charges->data ?? []) as $charge) {
+            if (is_object($charge)) {
+                return $charge;
+            }
+        }
+
+        $paymentIntentId = $this->extractPaymentIntentId($invoice);
+
+        return $paymentIntentId ? ($this->chargesByPaymentIntentId[$paymentIntentId] ?? null) : null;
+    }
+
+    private function prefetchChargesByPaymentIntentId(string $startDate, string $endDate): array
+    {
+        $queryOptions = [
+            'limit' => 100,
+            'created' => [
+                'gte' => Carbon::parse($startDate)->subDays($this->getAccountingLookbackDays())->startOfDay()->timestamp,
+                'lte' => Carbon::parse($endDate)->endOfDay()->timestamp,
+            ],
+            'expand' => [
+                'data.balance_transaction',
+                'data.refunds.data.balance_transaction',
+                'data.dispute',
+            ],
+        ];
+
+        $chargesByPaymentIntentId = [];
+        $charges = Cashier::stripe()->charges->all($queryOptions);
+
+        do {
+            foreach ($charges as $charge) {
+                $paymentIntentId = $charge->payment_intent ?? null;
+                if (!$paymentIntentId) {
+                    continue;
+                }
+
+                $existingCharge = $chargesByPaymentIntentId[$paymentIntentId] ?? null;
+                $candidateHasBalanceTransaction = isset($charge->balance_transaction) && is_object($charge->balance_transaction);
+                $existingHasBalanceTransaction = isset($existingCharge->balance_transaction) && is_object($existingCharge->balance_transaction);
+
+                if (!$existingCharge || ($candidateHasBalanceTransaction && !$existingHasBalanceTransaction)) {
+                    $chargesByPaymentIntentId[$paymentIntentId] = $charge;
+                }
+            }
+
+            if (empty($charges->data) || !$charges->has_more) {
+                break;
+            }
+
+            $queryOptions['starting_after'] = end($charges->data)->id;
+            $charges = Cashier::stripe()->charges->all($queryOptions);
+        } while (true);
+
+        return $chargesByPaymentIntentId;
+    }
+
+    private function extractPaymentIntentId(Invoice $invoice): ?string
+    {
+        foreach (($invoice->payments->data ?? []) as $payment) {
+            $paymentIntentId = $payment->payment->payment_intent ?? null;
+            if (!empty($paymentIntentId)) {
+                return (string) $paymentIntentId;
+            }
+        }
+
+        if (isset($invoice->payment_intent) && is_string($invoice->payment_intent)) {
+            return $invoice->payment_intent;
+        }
+
+        if (isset($invoice->payment_intent->id)) {
+            return $invoice->payment_intent->id;
+        }
+
+        return null;
+    }
+
+    private function getCustomerTaxIds(Invoice $invoice): array
+    {
+        $taxIds = $invoice->customer_tax_ids ?? ($invoice->customer->tax_ids->data ?? []);
+        if (is_array($taxIds)) {
+            return $taxIds;
+        }
+
+        if ($taxIds instanceof \Traversable) {
+            return iterator_to_array($taxIds, false);
+        }
+
+        if (is_iterable($taxIds)) {
+            $items = [];
+            foreach ($taxIds as $taxId) {
+                $items[] = $taxId;
+            }
+
+            return $items;
+        }
+
+        return [];
+    }
+
+    private function getAccountingLookbackDays(): int
+    {
+        return max(0, (int) env('STRIPE_EXPORT_LOOKBACK_DAYS', 14));
     }
 }

--- a/api/app/Services/Tax/StripeExportDatasetService.php
+++ b/api/app/Services/Tax/StripeExportDatasetService.php
@@ -63,7 +63,6 @@ class StripeExportDatasetService
             ],
             'status' => 'paid',
             'created' => [
-                'gte' => Carbon::parse($startDate)->subDays($this->getAccountingLookbackDays())->startOfDay()->timestamp,
                 'lte' => Carbon::parse($endDate)->endOfDay()->timestamp,
             ],
         ];
@@ -208,7 +207,7 @@ class StripeExportDatasetService
             'created_ts' => $invoice->created,
             'accounting_at' => $accountingAt->format('Y-m-d H:i:s'),
             'accounting_ts' => $accountingTs,
-            'cust_id' => $invoice->customer->id ?? 'unknown',
+            'cust_id' => $this->resolveCustomerId($invoice),
             'cust_vat_id' => $cleanVatId,
             'cust_country' => $country,
             'customer_type' => $customerType,
@@ -600,7 +599,6 @@ class StripeExportDatasetService
         $queryOptions = [
             'limit' => 100,
             'created' => [
-                'gte' => Carbon::parse($startDate)->subDays($this->getAccountingLookbackDays())->startOfDay()->timestamp,
                 'lte' => Carbon::parse($endDate)->endOfDay()->timestamp,
             ],
             'expand' => [
@@ -683,8 +681,20 @@ class StripeExportDatasetService
         return [];
     }
 
-    private function getAccountingLookbackDays(): int
+    private function resolveCustomerId(Invoice $invoice): string
     {
-        return max(0, (int) env('STRIPE_EXPORT_LOOKBACK_DAYS', 14));
+        if (isset($invoice->customer) && is_string($invoice->customer) && $invoice->customer !== '') {
+            return $invoice->customer;
+        }
+
+        if (isset($invoice->customer->id) && is_string($invoice->customer->id) && $invoice->customer->id !== '') {
+            return $invoice->customer->id;
+        }
+
+        if (isset($invoice->customer_id) && is_string($invoice->customer_id) && $invoice->customer_id !== '') {
+            return $invoice->customer_id;
+        }
+
+        return 'unknown';
     }
 }

--- a/api/app/Services/Tax/StripeExportDatasetStore.php
+++ b/api/app/Services/Tax/StripeExportDatasetStore.php
@@ -47,12 +47,13 @@ class StripeExportDatasetStore
         ], $metadata));
     }
 
-    public function writeChunk(string $datasetId, string $chunkKey, array $rows, array $stats = []): void
+    public function writeChunk(string $datasetId, string $chunkKey, array $rows, array $stats = [], array $balanceSummary = []): void
     {
         $this->writeJson($this->chunkPath($datasetId, $chunkKey), [
             'chunk_key' => $chunkKey,
             'row_count' => count($rows),
             'stats' => $stats,
+            'balance_summary' => $balanceSummary,
             'rows' => $rows,
         ]);
     }
@@ -64,6 +65,7 @@ class StripeExportDatasetStore
 
         $rows = [];
         $chunkSummaries = [];
+        $balanceSummary = [];
 
         foreach ($files as $file) {
             $payload = $this->readJson($file);
@@ -72,7 +74,9 @@ class StripeExportDatasetStore
                 'chunk_key' => $payload['chunk_key'] ?? basename($file, '.json'),
                 'row_count' => $payload['row_count'] ?? count($payload['rows'] ?? []),
                 'stats' => $payload['stats'] ?? [],
+                'balance_summary' => $payload['balance_summary'] ?? [],
             ];
+            $balanceSummary = $this->sumNumericMaps($balanceSummary, $payload['balance_summary'] ?? []);
         }
 
         usort($rows, function (array $left, array $right) {
@@ -86,6 +90,7 @@ class StripeExportDatasetStore
         $metadata['completed_at'] = now()->toIso8601String();
         $metadata['row_count'] = count($rows);
         $metadata['chunks'] = $chunkSummaries;
+        $metadata['balance_summary'] = $balanceSummary;
         $this->writeJson($this->metadataPath($datasetId), $metadata);
 
         return $rows;
@@ -108,6 +113,12 @@ class StripeExportDatasetStore
         return file_exists($path) ? $this->readJson($path) : [];
     }
 
+    public function updateMetadata(string $datasetId, array $attributes): void
+    {
+        $metadata = $this->readMetadata($datasetId);
+        $this->writeJson($this->metadataPath($datasetId), array_merge($metadata, $attributes));
+    }
+
     private function writeJson(string $path, array $payload): void
     {
         file_put_contents($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
@@ -116,5 +127,16 @@ class StripeExportDatasetStore
     private function readJson(string $path): array
     {
         return json_decode(file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    private function sumNumericMaps(array $left, array $right): array
+    {
+        $sum = $left;
+
+        foreach ($right as $key => $value) {
+            $sum[$key] = (float) ($sum[$key] ?? 0) + (float) $value;
+        }
+
+        return $sum;
     }
 }


### PR DESCRIPTION
## Summary
- fix Stripe tax export period handling and chunk dataset support
- improve invoice-level EUR calculations using Stripe balance transaction data
- separate refunds, credit notes, chargebacks, and add balance summary reconciliation rows
- update exporter headings so appended reconciliation columns are preserved

## Validation
- php -l on modified tax export files
- regenerated 2025 Stripe export files locally (not committed)