### PR TITLE
refactor: enhance mention parsing for email notifications

### DIFF
--- a/api/app/Notifications/Forms/FormEmailNotification.php
+++ b/api/app/Notifications/Forms/FormEmailNotification.php
@@ -87,7 +87,7 @@ class FormEmailNotification extends Notification
             ->markdown('mail.form.email-notification', $this->getMailData());
     }
 
-    private function formatSubmissionData($createLinks = true): array
+    private function formatSubmissionData(bool $createLinks = true, bool $forMentionParsing = false): array
     {
         $formatter = (new FormSubmissionFormatter($this->event->form, $this->event->data))
             ->outputStringsOnly()
@@ -96,7 +96,7 @@ class FormEmailNotification extends Notification
         if ($createLinks) {
             $formatter->createLinks();
         }
-        if ($this->integrationData->include_hidden_fields_submission_data ?? false) {
+        if ($forMentionParsing || ($this->integrationData->include_hidden_fields_submission_data ?? false)) {
             $formatter->showHiddenFields();
         }
 
@@ -136,7 +136,7 @@ class FormEmailNotification extends Notification
 
     private function getSenderName(): string
     {
-        $parser = new MentionParser($this->integrationData->sender_name ?? config('app.name'), $this->formatSubmissionData(false));
+        $parser = new MentionParser($this->integrationData->sender_name ?? config('app.name'), $this->formatSubmissionData(false, true));
         return $parser->parseAsText();
     }
 
@@ -154,14 +154,14 @@ class FormEmailNotification extends Notification
 
     private function parseReplyTo(string $replyTo): ?string
     {
-        $parser = new MentionParser($replyTo, $this->formatSubmissionData(false));
+        $parser = new MentionParser($replyTo, $this->formatSubmissionData(false, true));
         return $parser->parseAsText();
     }
 
     private function getSubject(): string
     {
         $defaultSubject = 'New form submission';
-        $parser = new MentionParser($this->integrationData->subject ?? $defaultSubject, $this->formatSubmissionData(false));
+        $parser = new MentionParser($this->integrationData->subject ?? $defaultSubject, $this->formatSubmissionData(false, true));
         return $parser->parseAsText();
     }
 
@@ -216,7 +216,7 @@ class FormEmailNotification extends Notification
 
     private function getEmailContent(): string
     {
-        $parser = new MentionParser($this->integrationData->email_content ?? '', $this->formatSubmissionData());
+        $parser = new MentionParser($this->integrationData->email_content ?? '', $this->formatSubmissionData(true, true));
         $html = $parser->parse();
 
         return $this->convertResizeAlignmentToInlineStyles($html);

--- a/api/tests/Feature/Forms/EmailNotificationTest.php
+++ b/api/tests/Feature/Forms/EmailNotificationTest.php
@@ -387,3 +387,42 @@ it('send email without the edit submission link', function () {
     expect(trim($renderedMail->render()))->toContain('Test body');
     expect(trim($renderedMail->render()))->not->toContain('Edit submission');
 });
+
+it('resolves mentions for hidden fields in email content when hidden submission data is excluded', function () {
+    $user = $this->actingAsUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace);
+
+    $hiddenField = [];
+    $form->properties = collect($form->properties)->map(function ($property) use (&$hiddenField) {
+        if ($property['type'] == 'email') {
+            $property['hidden'] = true;
+            $property['required'] = false;
+            $hiddenField = $property;
+        }
+        return $property;
+    })->toArray();
+    $form->update();
+
+    $integrationData = $this->createFormIntegration('email', $form->id, [
+        'send_to' => $user->email,
+        'sender_name' => 'OpnForm',
+        'subject' => 'New form submission',
+        'email_content' => '<p>Token: <span mention="true" mention-field-id="' . $hiddenField['id'] . '" mention-field-name="Secret token" mention-fallback=""></span></p>',
+        'include_submission_data' => true,
+        'include_hidden_fields_submission_data' => false,
+        'reply_to' => null,
+    ]);
+
+    $formData = [
+        $hiddenField['id'] => 'hidden-value-xyz'
+    ];
+
+    $event = new \App\Events\Forms\FormSubmitted($form, $formData);
+    $mailable = new FormEmailNotification($event, $integrationData, 'mail');
+    $notifiable = new AnonymousNotifiable();
+    $notifiable->route('mail', $user->email);
+    $renderedMail = $mailable->toMail($notifiable);
+
+    expect(trim($renderedMail->render()))->toContain('hidden-value-xyz');
+});


### PR DESCRIPTION
Updated the formatSubmissionData method to include a new parameter for mention parsing. Adjusted the usage of this method in various places to ensure hidden fields are correctly parsed in email content. Added a test to verify that mentions for hidden fields are resolved when hidden submission data is excluded.

Fixed: https://github.com/OpnForm/OpnForm/issues/1088