### PR TITLE
[codex] Fix submission table columns and checkbox labels

### DIFF
--- a/client/components/forms/core/CheckboxInput.vue
+++ b/client/components/forms/core/CheckboxInput.vue
@@ -32,6 +32,7 @@
             :label="label"
             :required="required"
             :theme="theme"
+            :native-for="id ? id : name"
           />
         </slot>
         <slot

--- a/client/components/open/forms/FormExportModal.vue
+++ b/client/components/open/forms/FormExportModal.vue
@@ -132,6 +132,25 @@ const animationFrame = ref(null)
 const lastApiCall = ref(null)
 const progressStartTime = ref(null)
 
+const normalizeColumnList = (columns) => {
+  if (Array.isArray(columns)) return columns
+  if (columns && typeof columns === 'object') return Object.values(columns)
+  return []
+}
+
+const exportColumns = computed(() => {
+  if (props.columns && Object.keys(props.columns).length > 0) {
+    return props.columns
+  }
+
+  return normalizeColumnList(props.form?.properties).reduce((columns, property) => {
+    if (property?.id) {
+      columns[property.id] = true
+    }
+    return columns
+  }, { created_at: true })
+})
+
 const startExport = () => {
   if (isExporting.value) return
 
@@ -145,7 +164,7 @@ const startExport = () => {
   progressStartTime.value = Date.now()
   
   const payload = {
-    columns: props.columns
+    columns: exportColumns.value
   }
 
   if (props.selectedIds.length > 0) {

--- a/client/composables/components/tables/useTableState.js
+++ b/client/composables/components/tables/useTableState.js
@@ -2,6 +2,18 @@ import { computed } from 'vue'
 import { useTableColumnPreferences } from './useTableColumnPreferences'
 import debounce from 'debounce'
 
+const normalizeColumnList = (columns) => {
+  if (Array.isArray(columns)) {
+    return columns
+  }
+
+  if (columns && typeof columns === 'object') {
+    return Object.values(columns)
+  }
+
+  return []
+}
+
 // Provides a composable for managing the state of a table component, including column visibility, pinning, sizing, and wrapping.
 // It synchronizes table state with user preferences (such as column order and visibility) and supports dynamic updates based on form structure and workspace context.
 
@@ -12,6 +24,7 @@ export function useTableState(form, withActions = false) {
   )
 
   const { getColumnPreference, setColumnPreference } = columnPreferences
+  const { hasFeature } = usePlanFeatures()
 
   /* -------------------------------------------------------------------------- */
   /*                               Column config                               */
@@ -20,9 +33,11 @@ export function useTableState(form, withActions = false) {
   // Computed column configurations (base definition for every column)
   const columnConfigurations = computed(() => {
     try {
-      if (!form.value?.properties || !Array.isArray(form.value.properties)) return []
+      const properties = normalizeColumnList(form.value?.properties)
+      const removedProperties = normalizeColumnList(form.value?.removed_properties)
+      if (properties.length === 0) return []
 
-      const baseColumns = form.value.properties
+      const baseColumns = properties
         .filter((field) => {
           return field.type && typeof field.type === 'string' && !field.type.startsWith('nf-')
         })
@@ -42,8 +57,8 @@ export function useTableState(form, withActions = false) {
         })
 
        // Add removed properties
-       if (form.value?.removed_properties) {
-         form.value.removed_properties.forEach(property => {
+       if (removedProperties.length > 0) {
+         removedProperties.forEach(property => {
            const { columns: matrixColumns, ...rest } = property
            baseColumns.push({
              ...(property.type === 'matrix' ? { ...rest, matrix_columns: matrixColumns } : { ...rest }),
@@ -70,8 +85,6 @@ export function useTableState(form, withActions = false) {
            maxSize: 500,
          })
        }
-
-       const { hasFeature } = usePlanFeatures()
 
        if (hasFeature('enable_partial_submissions') && (form.value?.enable_partial_submissions ?? false)) {
          if (!baseColumns.find(property => property.id === 'status')) {
@@ -443,4 +456,4 @@ export function useTableState(form, withActions = false) {
     toggleColumnPin: toggleColumnPin,
     handleColumnResize,
   }
-} 
+}

--- a/client/composables/query/forms/useForms.js
+++ b/client/composables/query/forms/useForms.js
@@ -9,21 +9,30 @@ export function useForms() {
   const { isAuthenticated } = useIsAuthenticated()
   const formsListCache = useFormsListCache()
 
+  const detailKey = (scope, slug) => ['forms', scope, 'slug', slug]
+  const detailByIdKey = (scope, id) => ['forms', scope, id]
+  const scopeFor = (usePrivate) => usePrivate ? 'private' : 'public'
+  const isQueryEnabled = (id, optionEnabled, usePrivate) => computed(() => {
+    return !!toValue(id) && !!toValue(optionEnabled) && (!usePrivate || isAuthenticated.value)
+  })
+
   const detail = (slug, options = {}) => {
-    const { usePrivate = false, ...queryOptions } = options
+    const { usePrivate = false, enabled = true, ...queryOptions } = options
+    const scope = scopeFor(usePrivate)
     
     return useQuery({
-      queryKey: ['forms', 'slug', slug],
+      queryKey: detailKey(scope, slug),
       queryFn: () => {
-        if (usePrivate && isAuthenticated.value) {
-          return formsApi.get(slug, options)
+        if (usePrivate) {
+          return formsApi.get(slug, queryOptions)
         }
-        return formsApi.publicGet(slug, options)
+        return formsApi.publicGet(slug, queryOptions)
       },
-      enabled: !!slug,
+      enabled: isQueryEnabled(slug, enabled, usePrivate),
       onSuccess: (form) => {
         if (form) {
           queryClient.setQueryData(['forms', form.id], form)
+          queryClient.setQueryData(detailKey(scope, form.slug), form)
         }
       },
       ...queryOptions,
@@ -31,20 +40,23 @@ export function useForms() {
   }
 
   const detailById = (id, options = {}) => {
-    const { usePrivate = false, ...queryOptions } = options
+    const { usePrivate = false, enabled = true, ...queryOptions } = options
+    const scope = scopeFor(usePrivate)
     
     return useQuery({
-      queryKey: ['forms', id],
+      queryKey: detailByIdKey(scope, id),
       queryFn: () => {
-        if (usePrivate && isAuthenticated.value) {
-          return formsApi.getById(id, options)
+        if (usePrivate) {
+          return formsApi.getById(id, queryOptions)
         }
-        return formsApi.publicGetById(id, options)
+        return formsApi.publicGetById(id, queryOptions)
       },
-      enabled: !!id,
+      enabled: isQueryEnabled(id, enabled, usePrivate),
       onSuccess: (form) => {
         if (form) {
-          queryClient.setQueryData(['forms', 'slug', form.slug], form)
+          queryClient.setQueryData(['forms', form.id], form)
+          queryClient.setQueryData(detailByIdKey(scope, form.id), form)
+          queryClient.setQueryData(detailKey(scope, form.slug), form)
         }
       },
       ...queryOptions,
@@ -60,7 +72,7 @@ export function useForms() {
         formsListCache.add(newForm.workspace_id, newForm)
         // Cache the new form
         queryClient.setQueryData(['forms', newForm.id], newForm)
-        queryClient.setQueryData(['forms', 'slug', newForm.slug], newForm)
+        queryClient.setQueryData(detailKey('private', newForm.slug), newForm)
       },
       ...options
     })
@@ -76,7 +88,7 @@ export function useForms() {
       // Update individual form cache
       queryClient.setQueryData(['forms', currentFormId], form)
       if (form.slug) {
-        queryClient.setQueryData(['forms', 'slug', form.slug], form)
+        queryClient.setQueryData(detailKey('private', form.slug), form)
       }
       
       // Update in workspace lists
@@ -111,7 +123,7 @@ export function useForms() {
       formsListCache.add(duplicatedForm.workspace_id, duplicatedForm)
       // Cache the duplicated form
       queryClient.setQueryData(['forms', duplicatedForm.id], duplicatedForm)
-      queryClient.setQueryData(['forms', 'slug', duplicatedForm.slug], duplicatedForm)
+      queryClient.setQueryData(detailKey('private', duplicatedForm.slug), duplicatedForm)
       },
       ...options
     })
@@ -125,7 +137,7 @@ export function useForms() {
         return old ? { ...old, ...updatedForm } : updatedForm
       })
       if (updatedForm.slug) {
-        queryClient.setQueryData(['forms', 'slug', updatedForm.slug], (old) => {
+        queryClient.setQueryData(detailKey('private', updatedForm.slug), (old) => {
           return old ? { ...old, ...updatedForm } : updatedForm
         })
       }
@@ -144,7 +156,7 @@ export function useForms() {
       // Update form cache
       queryClient.setQueryData(['forms', id], updatedForm)
       if (updatedForm.slug) {
-        queryClient.setQueryData(['forms', 'slug', updatedForm.slug], updatedForm)
+        queryClient.setQueryData(detailKey('private', updatedForm.slug), updatedForm)
       }
       
       // Remove from old workspace list
@@ -189,9 +201,12 @@ export function useForms() {
   const invalidateDetail = (form) => {
     if (form.id) {
       queryClient.removeQueries({ queryKey: ['forms', form.id] })
+      queryClient.removeQueries({ queryKey: detailByIdKey('public', form.id) })
+      queryClient.removeQueries({ queryKey: detailByIdKey('private', form.id) })
     }
     if (form.slug) {
-      queryClient.removeQueries({ queryKey: ['forms', 'slug', form.slug] })
+      queryClient.removeQueries({ queryKey: detailKey('public', form.slug) })
+      queryClient.removeQueries({ queryKey: detailKey('private', form.slug) })
     }
   }
 
@@ -217,4 +232,4 @@ export function useForms() {
     invalidateAll,
     invalidateDetail
   }
-} 
+}

--- a/client/test/nuxt/checkbox-input.spec.ts
+++ b/client/test/nuxt/checkbox-input.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import CheckboxInput from '../../components/forms/core/CheckboxInput.vue'
+
+describe('CheckboxInput', () => {
+  const createWrapper = (props = {}) => {
+    return mount(CheckboxInput, {
+      props: {
+        name: 'terms',
+        label: 'I accept the terms',
+        modelValue: false,
+        ...props,
+      },
+      global: {
+        stubs: {
+          InputWrapper: {
+            props: ['inputStyle'],
+            template: '<div :style="inputStyle"><slot name="label" /><slot /><slot name="help" /><slot name="error" /></div>',
+          },
+          Icon: true,
+        },
+        provide: {
+          form: undefined,
+        },
+      },
+    })
+  }
+
+  it('associates the visible label with the checkbox input', () => {
+    const wrapper = createWrapper({ id: 'terms-checkbox' })
+
+    const input = wrapper.find('input[type="checkbox"]')
+    const labels = wrapper.findAll('label')
+    const visibleLabel = labels.find(label => label.text().includes('I accept the terms'))
+
+    expect(input.attributes('id')).toBe('terms-checkbox')
+    expect(visibleLabel?.attributes('for')).toBe('terms-checkbox')
+  })
+
+  it('falls back to the field name when no id is provided', () => {
+    const wrapper = createWrapper()
+
+    const input = wrapper.find('input[type="checkbox"]')
+    const labels = wrapper.findAll('label')
+    const visibleLabel = labels.find(label => label.text().includes('I accept the terms'))
+
+    expect(input.attributes('id')).toBe('terms')
+    expect(visibleLabel?.attributes('for')).toBe('terms')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the production submissions table/export regression and the checkbox label click bug on public forms.

## Root cause

The latest `main` commit `4702f270` moved conditional Status/IP columns into `useTableState`'s `columnConfigurations` computed and called `usePlanFeatures()` from inside that computed getter. That can run outside the normal setup composable context; the surrounding `try/catch` then returned an empty column list, so the submissions table and Columns menu had no form columns.

There was also an older fragility in `useForms`: public and private form detail queries shared the same cache keys and private detail calls could fall back to the public endpoint while auth was initializing. That could leave dashboard pages with an incomplete/lightweight form payload.

The export bug was a downstream symptom: when column visibility was empty, the export request sent an empty columns object.

For checkbox fields, the visible label next to the checkbox was not associated with the checkbox input. The only native label linked to the checkbox lived inside `VCheckbox`, but it had no visible text in this layout.

## Changes

- Move `usePlanFeatures()` out of the `columnConfigurations` computed while preserving the Status/IP feature checks from `main`.
- Normalize `properties` and `removed_properties` before building table columns.
- Split form detail query keys by public/private scope and make private queries wait for auth instead of falling back to public endpoints.
- Add an export fallback that sends all form property ids plus `created_at` when column visibility is empty.
- Associate the visible `CheckboxInput` label with the checkbox input via `native-for`.
- Add a component regression test for checkbox label/input association.

## Validation

- `npm run lint` in `client/`
- `NODE_OPTIONS='--no-experimental-webstorage' npm run test -- --run test/nuxt/checkbox-input.spec.ts test/unit/useFormInput.test.ts` in `client/`
- `./vendor/bin/pest tests/Feature/Forms/FormSubmissionExportTest.php tests/Feature/Submissions/SubmissionTest.php` in `api/`