### PR TITLE
fix: resolve submissions runtime errors after table column update

### DIFF
--- a/client/composables/components/tables/useTableState.js
+++ b/client/composables/components/tables/useTableState.js
@@ -1,4 +1,4 @@
-import { computed } from 'vue'
+import { computed, toValue } from 'vue'
 import { useTableColumnPreferences } from './useTableColumnPreferences'
 import debounce from 'debounce'
 
@@ -24,7 +24,9 @@ export function useTableState(form, withActions = false) {
   )
 
   const { getColumnPreference, setColumnPreference } = columnPreferences
-  const { hasFeature } = usePlanFeatures()
+  const isProForm = computed(() => {
+    return Boolean(toValue(form)?.is_pro)
+  })
 
   /* -------------------------------------------------------------------------- */
   /*                               Column config                               */
@@ -86,7 +88,7 @@ export function useTableState(form, withActions = false) {
          })
        }
 
-       if (hasFeature('enable_partial_submissions') && (form.value?.enable_partial_submissions ?? false)) {
+       if (isProForm.value && (form.value?.enable_partial_submissions ?? false)) {
          if (!baseColumns.find(property => property.id === 'status')) {
            baseColumns.push({
             id: 'status',
@@ -102,7 +104,7 @@ export function useTableState(form, withActions = false) {
          }
        }
 
-       if (hasFeature('enable_ip_tracking') && (form.value?.enable_ip_tracking ?? false)) {
+       if (isProForm.value && (form.value?.enable_ip_tracking ?? false)) {
          if (!baseColumns.find(property => property.id === 'ip_address')) {
            baseColumns.push({
             id: 'ip_address',

--- a/client/composables/query/forms/useForms.js
+++ b/client/composables/query/forms/useForms.js
@@ -1,5 +1,5 @@
 import { useQueryClient, useQuery, useMutation } from '@tanstack/vue-query'
-import { toValue } from 'vue'
+import { computed, toValue } from 'vue'
 import { formsApi } from '~/api/forms'
 import { useIsAuthenticated } from '~/composables/useAuthFlow'
 import { useFormsListCache } from './useFormsList'


### PR DESCRIPTION
### Motivation
- Replace an undefined `usePlanFeatures()` dependency that caused a runtime `ReferenceError` on the submissions page while keeping conditional Status/IP columns behavior intact.

### Description
- Replace `usePlanFeatures()` in `client/composables/components/tables/useTableState.js` with a reactive `isProForm` computed from the current `form.is_pro` and use it to gate the Status and IP Address columns.
- Add missing `computed` import in `client/composables/query/forms/useForms.js` to ensure the `isQueryEnabled` helper works without throwing.

### Testing
- Ran targeted ESLint on the modified files with `cd client && npx eslint composables/components/tables/useTableState.js composables/query/forms/useForms.js` and it succeeded.
- Ran the client lint script with `cd client && npm run lint` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef9d3dc3d4833397d6b04386a41fdb)