### PR TITLE
[codex] Fix exported signed file URLs

### DIFF
--- a/api/app/Service/Forms/FormSubmissionFormatter.php
+++ b/api/app/Service/Forms/FormSubmissionFormatter.php
@@ -348,8 +348,9 @@ class FormSubmissionFormatter
             // See: https://github.com/OpnForm/OpnForm/issues/1024
             $encodedFilename = FilenameUrlEncoder::encode($file);
 
-            return $this->useSignedUrlForFiles ? URL::signedRoute(
+            return $this->useSignedUrlForFiles ? URL::temporarySignedRoute(
                 'open.forms.submissions.file',
+                now()->addMinutes(config('vapor.signed_storage_url_expires_after', 5)),
                 [$formId, $encodedFilename]
             ) : route('open.forms.submissions.file', [$formId, $encodedFilename]);
         } catch (\Exception $e) {

--- a/api/tests/Feature/Forms/FormSubmissionExportTest.php
+++ b/api/tests/Feature/Forms/FormSubmissionExportTest.php
@@ -2,6 +2,8 @@
 
 use App\Models\User;
 use App\Models\Forms\FormSubmission;
+use App\Service\Storage\FileUploadPathService;
+use Illuminate\Support\Facades\Storage;
 
 function parseCsvRows(string $content): array
 {
@@ -319,4 +321,54 @@ it('does not include status column when partial submissions are disabled', funct
     $response->sendContent();
     $content = ob_get_clean();
     expect(str_contains($content, 'status'))->toBeFalse();
+});
+
+it('exports file urls with expiration and a valid signature', function () {
+    $user = $this->actingAsProUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace, [
+        'properties' => [
+            [
+                'id' => 'file_field',
+                'name' => 'Upload',
+                'type' => 'files',
+                'required' => false,
+            ],
+        ],
+    ]);
+
+    Storage::fake();
+    $fileName = 'test-signature.png';
+    Storage::put(FileUploadPathService::getFileUploadPath($form->id, $fileName), 'signed file content');
+
+    $form->submissions()->create([
+        'form_id' => $form->id,
+        'data' => [
+            'file_field' => [$fileName],
+        ],
+        'status' => FormSubmission::STATUS_COMPLETED,
+    ]);
+
+    $response = $this->postJson(route('open.forms.submissions.export', [
+        'form' => $form,
+    ]), [
+        'columns' => [
+            'file_field' => true,
+        ],
+    ]);
+
+    $response->assertSuccessful();
+
+    ob_start();
+    $response->sendContent();
+    $content = ob_get_clean();
+    $rows = parseCsvRows($content);
+    $fileColumnIndex = array_search('Upload', $rows[0], true);
+    $exportedFileUrl = $rows[1][$fileColumnIndex];
+
+    parse_str(parse_url($exportedFileUrl, PHP_URL_QUERY), $queryParameters);
+
+    expect($queryParameters)->toHaveKeys(['expires', 'signature']);
+
+    $this->get($exportedFileUrl)->assertOk();
 });


### PR DESCRIPTION
## Summary

Closes #1097.

Exported file and signature URLs now use temporary signed routes, so CSV/Excel/Sheets exports include the expiration parameter required by Laravel's signed middleware.

## Root Cause

The export formatter used `URL::signedRoute()` for file URLs. Those URLs included `signature` but no `expires`, while the route is consumed like the in-app temporary signed file URLs. Exported links could therefore fail with invalid signature errors.

## Changes

- Switch exported signed file URLs to `URL::temporarySignedRoute()` using the existing Vapor signed storage expiration config.
- Add a regression test that exports a file field, parses the generated CSV URL, verifies both `expires` and `signature`, and confirms the exported URL is accessible.

## Validation

- `./vendor/bin/pest --filter="exports file urls with expiration and a valid signature"`
- `./vendor/bin/pest tests/Feature/Forms/FormSubmissionExportTest.php tests/Feature/Forms/FileDownloadSecurityTest.php tests/Feature/Forms/FileDownloadSpecialCharsTest.php`

Note: tests pass with an existing PHP deprecation warning in `tests/TestHelpers.php` about nullable parameter typing.
