### PR TITLE
[codex] Improve form creation and import flows

### DIFF
--- a/api/app/Jobs/Form/GenerateAiForm.php
+++ b/api/app/Jobs/Form/GenerateAiForm.php
@@ -17,8 +17,6 @@ class GenerateAiForm implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
-    protected string $model = 'o4-mini';
-
     /**
      * Create a new job instance.
      *

--- a/api/app/Service/AI/Prompts/Form/CheckSpamFormPrompt.php
+++ b/api/app/Service/AI/Prompts/Form/CheckSpamFormPrompt.php
@@ -10,7 +10,7 @@ class CheckSpamFormPrompt extends Prompt
 {
     protected ?float $temperature = 0.2;
     protected ?int $maxTokens = 500;
-    protected string $model = 'gpt-4.1-mini';
+    protected string $model = 'gpt-5.4-nano';
 
     public const PROMPT_TEMPLATE = <<<'EOD'
         {blockingConsiderations}

--- a/api/app/Service/AI/Prompts/Form/GenerateFormFieldsPrompt.php
+++ b/api/app/Service/AI/Prompts/Form/GenerateFormFieldsPrompt.php
@@ -10,7 +10,7 @@ class GenerateFormFieldsPrompt extends Prompt
 
     protected ?int $maxTokens = null;
 
-    protected string $model = 'o4-mini';
+    protected string $model = 'gpt-5.4-mini';
 
     /**
      * The prompt template for generating forms

--- a/api/app/Service/AI/Prompts/Form/GenerateFormPrompt.php
+++ b/api/app/Service/AI/Prompts/Form/GenerateFormPrompt.php
@@ -10,7 +10,7 @@ class GenerateFormPrompt extends Prompt
 
     protected ?int $maxTokens = null;
 
-    protected string $model = 'o4-mini';
+    protected string $model = 'gpt-5.4-mini';
 
     /**
      * The prompt template for generating forms

--- a/api/app/Service/AI/Prompts/Integration/CheckSpamEmailIntegrationPrompt.php
+++ b/api/app/Service/AI/Prompts/Integration/CheckSpamEmailIntegrationPrompt.php
@@ -11,7 +11,7 @@ class CheckSpamEmailIntegrationPrompt extends Prompt
 {
     protected ?float $temperature = 0.2;
     protected ?int $maxTokens = 500;
-    protected string $model = 'gpt-4.1-mini';
+    protected string $model = 'gpt-5.4-nano';
 
     public const PROMPT_TEMPLATE = <<<'EOD'
         Analyze this email notification integration for spam/phishing or unrelated content.

--- a/api/app/Service/AI/Prompts/Prompt.php
+++ b/api/app/Service/AI/Prompts/Prompt.php
@@ -36,7 +36,7 @@ abstract class Prompt
 
     public function __construct()
     {
-        $this->completer = new GptCompleter(null, 2, $this->model);
+        $this->completer = new GptCompleter($this->model);
     }
 
     protected function initialize(): void

--- a/api/app/Service/OpenAi/GptCompleter.php
+++ b/api/app/Service/OpenAi/GptCompleter.php
@@ -14,8 +14,6 @@ use OpenAI\Exceptions\ErrorException;
  */
 class GptCompleter
 {
-    public const AI_MODEL = 'gpt-4o';
-
     protected Client $openAi;
 
     protected mixed $result;
@@ -31,7 +29,7 @@ class GptCompleter
 
     protected bool $useStreaming = false;
 
-    public function __construct(?string $apiKey = null, protected int $retries = 2, protected string $model = self::AI_MODEL)
+    public function __construct(protected string $model, ?string $apiKey = null, protected int $retries = 2)
     {
         $this->openAi = \OpenAI::client($apiKey ?? config('services.openai.api_key'));
     }

--- a/api/config/links.php
+++ b/api/config/links.php
@@ -9,6 +9,6 @@ return [
     'discord' => 'https://discord.gg/YTSjU2a9TS',
     'twitter' => 'https://twitter.com/OpnForm',
     'zapier_integration' => 'https://zapier.com/developer/public-invite/146950/58db583730cc46b821614468d94c35de/',
-    'book_onboarding' => 'https://zcal.co/i/YQVGEULQ',
+    'book_onboarding' => 'https://cal.com/julien-nahum/opnform-intro-call',
     'feature_requests' => 'https://opnform.canny.io/feature-requests',
 ];

--- a/api/database/migrations/2026_02_14_000000_grandfather_legacy_pro_workspaces.php
+++ b/api/database/migrations/2026_02_14_000000_grandfather_legacy_pro_workspaces.php
@@ -1,0 +1,161 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class () extends Migration {
+    private const ACTIVE_STATUSES = ['trialing', 'active'];
+
+    private const MARKER_KEY = 'legacy_pro_grandfathering';
+
+    /**
+     * Features that were effectively available to legacy Pro workspaces before
+     * the multi-tier pricing split, but now require Business or Enterprise.
+     */
+    private const LEGACY_PRO_FEATURES = [
+        'branding.advanced',
+        'multi_user.roles',
+        'partial_submissions',
+        'enable_partial_submissions',
+        'database_fields_update',
+        'enable_ip_tracking',
+        'custom_css',
+        'seo_meta',
+        'sso.oidc',
+    ];
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('workspaces')
+            ->select(['id', 'plan_overrides'])
+            ->where(function ($query) {
+                $query
+                    ->whereExists(function ($exists) {
+                        $exists
+                            ->selectRaw('1')
+                            ->from('user_workspace')
+                            ->join('subscriptions', 'subscriptions.user_id', '=', 'user_workspace.user_id')
+                            ->whereColumn('user_workspace.workspace_id', 'workspaces.id')
+                            ->where('user_workspace.role', 'admin')
+                            ->where('subscriptions.type', 'default')
+                            ->whereIn('subscriptions.stripe_status', self::ACTIVE_STATUSES);
+                    })
+                    ->orWhereExists(function ($exists) {
+                        $exists
+                            ->selectRaw('1')
+                            ->from('user_workspace')
+                            ->join('licenses', 'licenses.user_id', '=', 'user_workspace.user_id')
+                            ->whereColumn('user_workspace.workspace_id', 'workspaces.id')
+                            ->where('user_workspace.role', 'admin')
+                            ->where('licenses.status', 'active');
+                    });
+            })
+            ->orderBy('id')
+            ->chunkById(100, function ($workspaces) {
+                foreach ($workspaces as $workspace) {
+                    $this->grandfatherWorkspace($workspace);
+                }
+            });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('workspaces')
+            ->select(['id', 'plan_overrides'])
+            ->whereNotNull('plan_overrides')
+            ->orderBy('id')
+            ->chunkById(100, function ($workspaces) {
+                foreach ($workspaces as $workspace) {
+                    $this->removeGrandfatheredFeatures($workspace);
+                }
+            });
+    }
+
+    private function grandfatherWorkspace(object $workspace): void
+    {
+        $overrides = $this->decodeOverrides($workspace->plan_overrides ?? null);
+        $existingFeatures = $this->normalizeStringList($overrides['features'] ?? []);
+        $featuresToAdd = array_values(array_diff(self::LEGACY_PRO_FEATURES, $existingFeatures));
+
+        if ($featuresToAdd === []) {
+            return;
+        }
+
+        $marker = is_array($overrides[self::MARKER_KEY] ?? null)
+            ? $overrides[self::MARKER_KEY]
+            : [];
+
+        $overrides['features'] = array_values(array_unique(array_merge($existingFeatures, $featuresToAdd)));
+        $overrides[self::MARKER_KEY] = [
+            'source' => 'legacy_default_pro',
+            'features' => array_values(array_unique(array_merge(
+                $this->normalizeStringList($marker['features'] ?? []),
+                $featuresToAdd,
+            ))),
+        ];
+
+        DB::table('workspaces')
+            ->where('id', $workspace->id)
+            ->update([
+                'plan_overrides' => json_encode($overrides),
+            ]);
+    }
+
+    private function removeGrandfatheredFeatures(object $workspace): void
+    {
+        $overrides = $this->decodeOverrides($workspace->plan_overrides ?? null);
+        $marker = $overrides[self::MARKER_KEY] ?? null;
+
+        if (!is_array($marker)) {
+            return;
+        }
+
+        $featuresToRemove = $this->normalizeStringList($marker['features'] ?? []);
+        $existingFeatures = $this->normalizeStringList($overrides['features'] ?? []);
+        $remainingFeatures = array_values(array_diff($existingFeatures, $featuresToRemove));
+
+        if ($remainingFeatures === []) {
+            unset($overrides['features']);
+        } else {
+            $overrides['features'] = $remainingFeatures;
+        }
+
+        unset($overrides[self::MARKER_KEY]);
+
+        DB::table('workspaces')
+            ->where('id', $workspace->id)
+            ->update([
+                'plan_overrides' => $overrides === [] ? null : json_encode($overrides),
+            ]);
+    }
+
+    private function decodeOverrides(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (!$value) {
+            return [];
+        }
+
+        $decoded = json_decode((string) $value, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function normalizeStringList(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_unique(array_filter($value, 'is_string')));
+    }
+};

--- a/api/tests/Feature/Subscriptions/LegacyProGrandfatheringMigrationTest.php
+++ b/api/tests/Feature/Subscriptions/LegacyProGrandfatheringMigrationTest.php
@@ -1,0 +1,162 @@
+<?php
+
+use App\Service\Billing\Feature;
+use App\Service\Billing\PlanAccessService;
+use App\Service\Forms\FormCleaner;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+function legacyProGrandfatheringMigration()
+{
+    return include database_path('migrations/2026_02_14_000000_grandfather_legacy_pro_workspaces.php');
+}
+
+it('grandfathers active legacy default subscriptions with moved pro features', function () {
+    $user = $this->createProUser();
+    $workspace = $this->createUserWorkspace($user);
+
+    legacyProGrandfatheringMigration()->up();
+
+    $workspace = $workspace->fresh();
+    $service = app(PlanAccessService::class);
+
+    expect($workspace->plan_tier)->toBe('pro');
+    expect($service->hasFeature($workspace, Feature::BRANDING_ADVANCED))->toBeTrue();
+    expect($service->hasFeature($workspace, Feature::PARTIAL_SUBMISSIONS))->toBeTrue();
+    expect($service->hasFeature($workspace, Feature::SSO_OIDC))->toBeTrue();
+    expect($service->hasFeature($workspace, Feature::FORM_VERSIONING))->toBeFalse();
+    expect($service->hasFormFeature($workspace, 'custom_css'))->toBeTrue();
+    expect($service->hasFormFeature($workspace, 'seo_meta'))->toBeTrue();
+    expect($service->hasFormFeature($workspace, 'enable_ip_tracking'))->toBeTrue();
+});
+
+it('does not grandfather new named pro subscriptions', function () {
+    $user = $this->createUser();
+    $user->subscriptions()->create([
+        'type' => 'pro',
+        'stripe_id' => (string) Str::uuid(),
+        'stripe_status' => 'active',
+        'stripe_price' => (string) Str::uuid(),
+        'quantity' => 1,
+    ]);
+    $workspace = $this->createUserWorkspace($user);
+
+    legacyProGrandfatheringMigration()->up();
+
+    $workspace = $workspace->fresh();
+    $service = app(PlanAccessService::class);
+
+    expect($workspace->plan_overrides)->toBeNull();
+    expect($workspace->plan_tier)->toBe('pro');
+    expect($service->hasFeature($workspace, Feature::BRANDING_ADVANCED))->toBeFalse();
+    expect($service->hasFormFeature($workspace, 'custom_css'))->toBeFalse();
+});
+
+it('grandfathers trialing legacy default subscriptions', function () {
+    $user = $this->createUser();
+    $user->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => (string) Str::uuid(),
+        'stripe_status' => 'trialing',
+        'stripe_price' => (string) Str::uuid(),
+        'trial_ends_at' => now()->addDays(5),
+        'quantity' => 1,
+    ]);
+    $workspace = $this->createUserWorkspace($user);
+
+    legacyProGrandfatheringMigration()->up();
+
+    $service = app(PlanAccessService::class);
+
+    expect($service->hasFeature($workspace->fresh(), Feature::BRANDING_ADVANCED))->toBeTrue();
+});
+
+it('does not grandfather ended legacy default subscriptions', function () {
+    $user = $this->createUser();
+    $user->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => (string) Str::uuid(),
+        'stripe_status' => 'canceled',
+        'stripe_price' => (string) Str::uuid(),
+        'ends_at' => now()->subDay(),
+        'quantity' => 1,
+    ]);
+    $workspace = $this->createUserWorkspace($user);
+
+    legacyProGrandfatheringMigration()->up();
+
+    expect($workspace->fresh()->plan_overrides)->toBeNull();
+});
+
+it('keeps moved pro form features available after legacy grandfathering', function () {
+    $user = $this->createProUser();
+    $this->actingAsUser($user);
+    $workspace = $this->createUserWorkspace($user);
+
+    legacyProGrandfatheringMigration()->up();
+    $workspace = $workspace->fresh();
+
+    $form = $this->createForm($user, $workspace, [
+        'custom_css' => 'body { color: red; }',
+        'seo_meta' => ['page_title' => 'Legacy Pro'],
+        'enable_partial_submissions' => true,
+        'enable_ip_tracking' => true,
+        'database_fields_update' => ['field' => 'email'],
+    ]);
+
+    $cleaner = (new FormCleaner())
+        ->processForm(Request::create('/', 'GET'), $form)
+        ->performCleaning($workspace);
+
+    $data = $cleaner->getData();
+
+    expect($data['custom_css'])->toBe('body { color: red; }');
+    expect((array) $data['seo_meta'])->toBe(['page_title' => 'Legacy Pro']);
+    expect($data['enable_partial_submissions'])->toBeTrue();
+    expect($data['enable_ip_tracking'])->toBeTrue();
+    expect($data['database_fields_update'])->toBe(['field' => 'email']);
+    expect($cleaner->hasCleaned())->toBeFalse();
+});
+
+it('grandfathers active lifetime licenses too', function () {
+    $user = $this->createAppSumoLicensedUser(2);
+    $workspace = $this->createUserWorkspace($user);
+
+    legacyProGrandfatheringMigration()->up();
+
+    $workspace = $workspace->fresh();
+    $service = app(PlanAccessService::class);
+
+    expect($workspace->plan_tier)->toBe('pro');
+    expect($service->hasFeature($workspace, Feature::BRANDING_ADVANCED))->toBeTrue();
+    expect($service->hasFormFeature($workspace, 'custom_css'))->toBeTrue();
+});
+
+it('rolls back only features added by the grandfathering migration', function () {
+    $user = $this->createProUser();
+    $workspace = $this->createUserWorkspace($user);
+    $workspace->update([
+        'plan_overrides' => [
+            'features' => [
+                Feature::SSO_OIDC,
+                'custom_domain.wildcard',
+            ],
+            'limits' => [
+                'custom_domain_count' => 25,
+            ],
+        ],
+    ]);
+
+    $migration = legacyProGrandfatheringMigration();
+    $migration->up();
+    $migration->down();
+
+    $overrides = $workspace->fresh()->plan_overrides;
+
+    expect($overrides['features'])->toContain(Feature::SSO_OIDC);
+    expect($overrides['features'])->toContain('custom_domain.wildcard');
+    expect($overrides['features'])->not->toContain(Feature::BRANDING_ADVANCED);
+    expect($overrides['features'])->not->toContain('custom_css');
+    expect($overrides['limits'])->toBe(['custom_domain_count' => 25]);
+    expect($overrides)->not->toHaveKey('legacy_pro_grandfathering');
+});

--- a/client/components/forms/import/FormImportModal.vue
+++ b/client/components/forms/import/FormImportModal.vue
@@ -269,7 +269,6 @@ const selectedProviderId = ref(null)
 const appStore = useAppStore()
 const oAuth = useOAuth()
 const { isAuthenticated: authenticated } = useIsAuthenticated()
-const { data: providersData, isLoading: loadingProviders } = oAuth.providers()
 const isGoogleImportConfigured = computed(() => {
   return !!useFeatureFlag('services.google.auth', false) && !useFeatureFlag('self_hosted', false)
 })
@@ -334,6 +333,12 @@ const sourceIssue = computed(() => {
   }
 
   return importDetection.value.reason
+})
+const shouldFetchGoogleProviders = computed(() => {
+  return props.show && authenticated.value && isGoogleImportConfigured.value && isGoogleSource.value
+})
+const { data: providersData, isLoading: loadingProviders } = oAuth.providers({
+  enabled: shouldFetchGoogleProviders,
 })
 
 const filteredProviders = computed(() =>

--- a/client/components/forms/import/FormImportModal.vue
+++ b/client/components/forms/import/FormImportModal.vue
@@ -1,71 +1,245 @@
 <template>
   <UModal
     v-model:open="isOpen"
-    :ui="{ content: 'sm:max-w-lg' }"
+    :ui="{ content: 'sm:max-w-2xl overflow-hidden' }"
     :dismissible="!loading"
   >
     <template #header>
-      <div class="flex items-center justify-between w-full">
-        <div class="grow w-full">
-          <h3 class="text-base font-semibold leading-6 text-neutral-900 dark:text-white">
-            {{selectedSource ? 'Import from ' + sourceLabel : 'Import form'}}
-          </h3>
-          <p v-if="!selectedSource" class="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
-            Select the platform you want to import from
-          </p>
+      <div class="flex w-full items-start justify-between gap-4">
+        <div class="flex min-w-0 items-start gap-3">
+          <span class="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-emerald-100 bg-emerald-50 text-emerald-600">
+            <Icon
+              name="i-heroicons-arrow-down-tray"
+              class="h-5 w-5"
+            />
+          </span>
+          <div class="min-w-0">
+            <h3 class="text-base font-semibold leading-6 text-neutral-950 dark:text-white">
+              Import form
+            </h3>
+            <p class="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
+              Paste a supported form URL and OpnForm will detect the provider.
+            </p>
+          </div>
         </div>
-        <UButton color="neutral" variant="ghost" icon="i-heroicons-x-mark-20-solid" class="-my-1" @click="isOpen = false" />
-      </div>
-    </template>
-    <template #body>
-      <!-- Choose source -->
-      <FormImportSourcePicker
-        v-if="step === 'source'"
-        :allow-google-forms="authenticated"
-        @select="selectSource"
-      />
-
-      <!-- URL based sources -->
-      <FormImportUrlInput
-        v-else-if="step === 'url'"
-        :form="importForm"
-        :url-placeholder="urlPlaceholder"
-        :loading="loading"
-        @submit="submitImport"
-        @back="step = 'source'"
-      />
-
-      <!-- OAuth based sources -->
-      <FormImportOAuth
-        v-else-if="step === 'oauth'"
-        :form="importForm"
-        v-bind="oauthConfig"
-        :url-placeholder="urlPlaceholder"
-        :loading="loading"
-        @submit="submitImport"
-      />
-
-      <div 
-        v-if="step !== 'source'"
-        class="flex gap-2 mt-4"
-      >
         <UButton
-          variant="ghost"
           color="neutral"
-          icon="i-heroicons-arrow-left"
-          @click="handleBack"
-          label="Back"
+          variant="ghost"
+          icon="i-heroicons-x-mark-20-solid"
+          class="-mr-2 -mt-1"
+          @click="isOpen = false"
         />
       </div>
+    </template>
+
+    <template #body>
+      <form @submit.prevent="submitImport">
+        <div class="overflow-hidden rounded-lg border border-neutral-200 bg-white shadow-[0_20px_55px_-38px_rgba(15,23,42,0.55)]">
+          <div class="flex items-center gap-3 border-b border-neutral-100 bg-neutral-50/80 px-3 py-2">
+            <span
+              class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border text-sm shadow-sm"
+              :class="activeSourceConfig ? activeSourceConfig.iconWrapClass : 'border-neutral-200 bg-white text-neutral-500'"
+            >
+              <Icon
+                :name="activeSourceConfig?.icon || 'i-heroicons-link'"
+                :class="activeSourceConfig?.iconClass || 'h-4 w-4'"
+              />
+            </span>
+            <div class="min-w-0 flex-1">
+              <input
+                v-model="importForm.url"
+                type="text"
+                inputmode="url"
+                name="url"
+                autocomplete="url"
+                aria-label="Form URL"
+                :placeholder="activePlaceholder"
+                :disabled="loading"
+                class="w-full border-0 bg-transparent px-0 py-2 text-base font-medium text-neutral-950 placeholder:text-neutral-400 focus:outline-none focus:ring-0 disabled:cursor-not-allowed disabled:opacity-70"
+                @input="handleUrlInput"
+              >
+            </div>
+            <UButton
+              type="submit"
+              icon="i-heroicons-arrow-down-tray"
+              :loading="loading"
+              :disabled="!canSubmit"
+              :color="canSubmit ? 'primary' : 'neutral'"
+              :variant="canSubmit ? 'solid' : 'soft'"
+              label="Import"
+              class="shrink-0"
+            />
+          </div>
+
+          <div class="flex flex-col gap-3 px-3 py-3 sm:flex-row sm:items-center sm:justify-between">
+            <div
+              class="flex min-w-0 items-start gap-2 text-sm"
+              :class="statusClass"
+            >
+              <Icon
+                :name="statusIcon"
+                class="mt-0.5 h-4 w-4 shrink-0"
+              />
+              <span class="min-w-0">{{ statusMessage }}</span>
+            </div>
+            <button
+              v-if="importForm.url"
+              type="button"
+              class="w-fit text-xs font-medium text-neutral-400 transition hover:text-neutral-700"
+              @click="clearUrl"
+            >
+              Clear
+            </button>
+          </div>
+        </div>
+      </form>
+
+      <div class="mt-4">
+        <div class="mb-2 flex items-center justify-between gap-3">
+          <p class="text-xs font-medium uppercase text-neutral-400">
+            Supported imports
+          </p>
+          <UBadge
+            v-if="detectedSourceConfig && !sourceIssue"
+            color="primary"
+            variant="soft"
+            size="sm"
+            :label="detectedSourceConfig.label + ' detected'"
+          />
+        </div>
+
+        <div
+          class="grid grid-cols-1 gap-2"
+          :class="supportedSources.length === 4 ? 'sm:grid-cols-4' : 'sm:grid-cols-3'"
+        >
+          <div
+            v-for="source in supportedSources"
+            :key="source.id"
+            class="min-w-0 rounded-lg border bg-white p-3 shadow-sm transition duration-200"
+            :class="sourceCardClass(source)"
+          >
+            <div class="mb-3 flex items-start justify-between gap-2">
+              <span
+                class="flex h-9 w-9 items-center justify-center rounded-lg border shadow-sm"
+                :class="source.iconWrapClass"
+              >
+                <Icon
+                  :name="source.icon"
+                  :class="source.iconClass"
+                />
+              </span>
+              <Icon
+                v-if="detectedSource === source.id && !sourceIssue"
+                name="i-heroicons-check-circle"
+                class="h-4 w-4 text-blue-600"
+              />
+              <Icon
+                v-else-if="source.requiresAuth && !authenticated"
+                name="i-heroicons-lock-closed"
+                class="h-4 w-4 text-neutral-300"
+              />
+            </div>
+            <p class="text-sm font-semibold text-neutral-950">{{ source.label }}</p>
+            <p
+              class="mt-1 max-w-full truncate text-xs leading-5 text-neutral-500"
+              :title="source.domain"
+            >
+              {{ source.domain }}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <VTransition name="fade">
+        <div
+          v-if="isGoogleSource && !sourceIssue"
+          class="mt-4 rounded-lg border border-neutral-200 bg-white p-4 shadow-sm"
+        >
+          <div
+            v-if="!authenticated"
+            class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+          >
+            <div class="min-w-0">
+              <p class="text-sm font-semibold text-neutral-950">Google Forms needs an account</p>
+              <p class="mt-1 text-sm text-neutral-500">
+                We need read-only access to your Google Forms to import this URL.
+              </p>
+            </div>
+            <UButton
+              label="Log in to import"
+              icon="i-heroicons-user-circle"
+              class="justify-center"
+              @click="appStore.quickRegisterModal = true"
+            />
+          </div>
+
+          <div
+            v-else-if="loadingProviders"
+            class="py-4 text-center"
+          >
+            <Loader class="mx-auto mb-3 h-6 w-6" />
+            <p class="text-sm text-neutral-500">Checking Google connection...</p>
+          </div>
+
+          <div v-else-if="filteredProviders.length">
+            <FlatSelectInput
+              v-model="selectedProviderId"
+              :form="importForm"
+              name="oauth_provider_id"
+              :options="filteredProviders"
+              :disable-options="disabledProviderIds"
+              disable-options-tooltip="Re-connect account to fix permissions"
+              display-key="email"
+              option-key="id"
+              emit-key="id"
+              :required="true"
+              label="Google account"
+            >
+              <template #help>
+                <InputHelp>
+                  <span>
+                    <a
+                      class="cursor-pointer text-blue-500"
+                      @click="connectProvider"
+                    >
+                      Connect another account
+                    </a>
+                  </span>
+                </InputHelp>
+              </template>
+            </FlatSelectInput>
+          </div>
+
+          <div
+            v-else
+            class="text-center"
+          >
+            <div class="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-lg border border-blue-100 bg-blue-50 text-blue-600">
+              <Icon
+                name="i-simple-icons-google"
+                class="h-5 w-5"
+              />
+            </div>
+            <UButton
+              :loading="connecting"
+              label="Connect Google"
+              icon="i-simple-icons-google"
+              @click="connectProvider"
+            />
+            <p class="mx-auto mt-3 max-w-sm text-sm leading-6 text-neutral-500">
+              We need read-only access to import your Google Forms.
+            </p>
+          </div>
+        </div>
+      </VTransition>
     </template>
   </UModal>
 </template>
 
 <script setup>
-import FormImportSourcePicker from './FormImportSourcePicker.vue'
-import FormImportUrlInput from './FormImportUrlInput.vue'
-import FormImportOAuth from './FormImportOAuth.vue'
 import { formsApi } from '~/api/forms'
+import { WindowMessageTypes, useWindowMessage } from '~/composables/useWindowMessage'
+import { detectFormImportSource } from '~/lib/forms/detect-form-import-source'
 
 const props = defineProps({
   show: { type: Boolean, required: true },
@@ -81,89 +255,265 @@ const isOpen = computed({
   },
 })
 
-const step = ref('source')
-const selectedSource = ref(null)
-const loading = ref(false)
-
 const importForm = useForm({
   url: '',
   oauth_provider_id: null,
 })
 
-const oAuth = useOAuth()
-
-const sourceConfigs = {
-  typeform: { label: 'Typeform', placeholder: 'https://example.typeform.com/to/abc123' },
-  tally: { label: 'Tally', placeholder: 'https://tally.so/r/mBGjOq' },
-  fillout: { label: 'Fillout', placeholder: 'https://example.fillout.com/t/abc123' },
-  google_forms: {
-    label: 'Google Forms',
-    placeholder: 'https://docs.google.com/forms/d/.../edit',
-    oauth: {
-      provider: 'google',
-      providerLabel: 'Google',
-      sourceLabel: 'Google Forms',
-      requiredScope: oAuth.googleFormsPermissionScope,
-      connectIcon: 'i-simple-icons-google',
-      connectHelpText: 'We need read-only access to import your Google Forms.',
-      helpText: 'Use the edit URL of your form. Published URLs (/d/e/...) are not supported.',
-    },
-  }
-}
-
-const sourceLabel = computed(() => sourceConfigs[selectedSource.value]?.label ?? '')
-const urlPlaceholder = computed(() => sourceConfigs[selectedSource.value]?.placeholder ?? '')
-const oauthConfig = computed(() => sourceConfigs[selectedSource.value]?.oauth ?? {})
-const guestAllowedSources = ['typeform', 'tally', 'fillout']
+const loading = ref(false)
+const importError = ref('')
+const suggestedSource = ref(null)
+const connecting = ref(false)
+const selectedProviderId = ref(null)
 
 const appStore = useAppStore()
+const oAuth = useOAuth()
 const { isAuthenticated: authenticated } = useIsAuthenticated()
+const { data: providersData, isLoading: loadingProviders } = oAuth.providers()
+const isGoogleImportConfigured = computed(() => {
+  return !!useFeatureFlag('services.google.auth', false) && !useFeatureFlag('self_hosted', false)
+})
+const showGoogleImportSource = computed(() => isGoogleImportConfigured.value && authenticated.value)
 
-watch(() => props.show, (open) => {
-  if (open) {
-    const defaultSource = props.defaultSource ?? null
-    if (!authenticated.value && defaultSource && !guestAllowedSources.includes(defaultSource)) {
-      appStore.quickRegisterModal = true
-      emit('close')
-      return
-    }
-    selectSource(defaultSource)
+const sourceConfigs = {
+  typeform: {
+    id: 'typeform',
+    label: 'Typeform',
+    domain: 'typeform.com/to/...',
+    placeholder: 'https://example.typeform.com/to/abc123',
+    icon: 'i-simple-icons-typeform',
+    iconClass: 'h-4 w-4 text-[#262627]',
+    iconWrapClass: 'border-neutral-200 bg-white text-neutral-950',
+  },
+  tally: {
+    id: 'tally',
+    label: 'Tally',
+    domain: 'tally.so/r/...',
+    placeholder: 'https://tally.so/r/mBGjOq',
+    icon: 'opnform:tally',
+    iconClass: 'h-4 w-4 text-[#725BFF]',
+    iconWrapClass: 'border-violet-100 bg-violet-50 text-violet-600',
+  },
+  fillout: {
+    id: 'fillout',
+    label: 'Fillout',
+    domain: 'fillout.com/t/...',
+    placeholder: 'https://example.fillout.com/t/abc123',
+    icon: 'i-simple-icons-fillout',
+    iconClass: 'h-4 w-4 text-[#FFC738]',
+    iconWrapClass: 'border-amber-100 bg-amber-50 text-amber-600',
+  },
+  google_forms: {
+    id: 'google_forms',
+    label: 'Google Forms',
+    domain: 'docs.google.com/forms/d/...',
+    placeholder: 'https://docs.google.com/forms/d/.../edit',
+    icon: 'i-simple-icons-googleforms',
+    iconClass: 'h-4 w-4 text-[#7248B9]',
+    iconWrapClass: 'border-purple-100 bg-purple-50 text-purple-600',
+    requiresAuth: true,
+  },
+}
+
+const supportedSources = computed(() => Object.values(sourceConfigs).filter((source) => {
+  return source.id !== 'google_forms' || showGoogleImportSource.value
+}))
+const supportedSourceConfigs = computed(() => {
+  return Object.fromEntries(supportedSources.value.map(source => [source.id, source]))
+})
+const importDetection = computed(() => detectFormImportSource(importForm.url))
+const detectedSource = computed(() => importDetection.value.source)
+const isGoogleSource = computed(() => detectedSource.value === 'google_forms')
+const detectedSourceConfig = computed(() => supportedSourceConfigs.value[detectedSource.value] ?? null)
+const activeSourceConfig = computed(() => detectedSourceConfig.value ?? supportedSourceConfigs.value[suggestedSource.value] ?? null)
+const supportedSourcesLabel = computed(() => formatSourceList(supportedSources.value.map(source => source.label)))
+const activePlaceholder = computed(() => activeSourceConfig.value?.placeholder ?? `Paste a ${supportedSourcesLabel.value} URL`)
+const sourceIssue = computed(() => {
+  if (isGoogleSource.value && !isGoogleImportConfigured.value) {
+    return 'google_unavailable'
   }
+
+  return importDetection.value.reason
 })
 
-const selectSource = (source) => {
-  if (!authenticated.value && sourceConfigs[source]?.oauth) {
-    appStore.quickRegisterModal = true
-    emit('close')
+const filteredProviders = computed(() =>
+  (providersData.value || []).filter(provider => provider.provider === 'google')
+)
+
+const disabledProviderIds = computed(() => {
+  return filteredProviders.value
+    .filter(provider => !provider.scopes?.includes(oAuth.googleFormsPermissionScope))
+    .map(provider => provider.id)
+})
+
+const validGoogleProviders = computed(() => {
+  return filteredProviders.value.filter(provider => !disabledProviderIds.value.includes(provider.id))
+})
+
+const canSubmit = computed(() => {
+  if (loading.value || !importForm.url || !detectedSource.value || sourceIssue.value) {
+    return false
+  }
+
+  if (!isGoogleSource.value) {
+    return true
+  }
+
+  return authenticated.value && !!selectedProviderId.value
+})
+
+const statusIcon = computed(() => {
+  if (importError.value || sourceIssue.value || (importForm.url && !detectedSource.value)) {
+    return 'i-heroicons-exclamation-circle'
+  }
+
+  if (detectedSource.value) {
+    return 'i-heroicons-check-circle'
+  }
+
+  return 'i-heroicons-sparkles'
+})
+
+const statusClass = computed(() => {
+  if (importError.value || sourceIssue.value || (importForm.url && !detectedSource.value)) {
+    return 'text-red-600'
+  }
+
+  if (detectedSource.value) {
+    return 'text-blue-600'
+  }
+
+  return 'text-neutral-500'
+})
+
+const statusMessage = computed(() => {
+  if (importError.value) {
+    return importError.value
+  }
+
+  if (!importForm.url) {
+    return 'Paste a URL and we will detect the import source automatically.'
+  }
+
+  if (sourceIssue.value) {
+    return issueMessage(sourceIssue.value)
+  }
+
+  if (!detectedSource.value) {
+    return 'This URL is not from a supported import source.'
+  }
+
+  if (isGoogleSource.value && !authenticated.value) {
+    return 'Google Forms detected. Log in to connect Google and import this form.'
+  }
+
+  if (isGoogleSource.value && authenticated.value && !selectedProviderId.value) {
+    return 'Google Forms detected. Select a Google account before importing.'
+  }
+
+  return `${detectedSourceConfig.value.label} detected. Ready to import.`
+})
+
+watch(() => props.show, (open) => {
+  if (!open) {
+    loading.value = false
+    importError.value = ''
+    connecting.value = false
     return
   }
 
-  selectedSource.value = source
+  suggestedSource.value = props.defaultSource ?? null
   importForm.url = ''
   importForm.oauth_provider_id = null
+  selectedProviderId.value = null
+  importForm.errors.clear()
+  importError.value = ''
+})
+
+watch(detectedSource, (source) => {
+  importError.value = ''
   importForm.errors.clear()
 
-  if (source === null) {
-    step.value = 'source'
-  } else if (sourceConfigs[source]?.oauth) {
-    step.value = 'oauth'
-  } else {
-    step.value = 'url'
+  if (source !== 'google_forms') {
+    importForm.oauth_provider_id = null
+    selectedProviderId.value = null
   }
+})
+
+watch([validGoogleProviders, detectedSource], ([providers, source]) => {
+  if (source !== 'google_forms' || selectedProviderId.value || providers.length !== 1) {
+    return
+  }
+
+  selectedProviderId.value = providers[0].id
+  importForm.oauth_provider_id = providers[0].id
+})
+
+watch(selectedProviderId, (providerId) => {
+  importForm.oauth_provider_id = providerId
+  importError.value = ''
+})
+
+const handleUrlInput = () => {
+  importError.value = ''
+  importForm.errors.clear()
 }
 
-const handleBack = () => {
-  selectSource(null)
+const clearUrl = () => {
+  importForm.url = ''
+  importError.value = ''
+  importForm.errors.clear()
+}
+
+const sourceCardClass = (source) => {
+  if (detectedSource.value === source.id && !sourceIssue.value) {
+    return 'border-blue-200 ring-1 ring-blue-100'
+  }
+
+  if (source.requiresAuth && !authenticated.value) {
+    return 'border-neutral-200 opacity-70'
+  }
+
+  return 'border-neutral-200'
 }
 
 const submitImport = () => {
-  if (loading.value || !importForm.url) return
+  if (loading.value) return
+
+  if (!detectedSource.value) {
+    importError.value = importForm.url ? 'This URL is not from a supported import source.' : 'A form URL is required.'
+    return
+  }
+
+  if (sourceIssue.value) {
+    importError.value = issueMessage(sourceIssue.value)
+    return
+  }
+
+  if (isGoogleSource.value && !authenticated.value) {
+    appStore.quickRegisterModal = true
+    return
+  }
+
+  if (isGoogleSource.value && !selectedProviderId.value) {
+    importError.value = 'Select a Google account to import this form.'
+    return
+  }
 
   loading.value = true
+  importError.value = ''
+
+  const importData = {
+    url: importDetection.value.normalizedUrl,
+  }
+
+  if (isGoogleSource.value) {
+    importData.oauth_provider_id = selectedProviderId.value
+  }
 
   formsApi.import({
-    source: selectedSource.value,
-    import_data: importForm.data(),
+    source: detectedSource.value,
+    import_data: importData,
   })
     .then((response) => {
       useAlert().success(response.message || 'Form imported successfully!')
@@ -172,10 +522,62 @@ const submitImport = () => {
     })
     .catch((error) => {
       const message = error?.data?.message || error?.message || 'Failed to import form. Please check the URL and try again.'
+      importError.value = message
       useAlert().error(message)
     })
     .finally(() => {
       loading.value = false
     })
 }
+
+const connectProvider = () => {
+  connecting.value = true
+  oAuth.connect('google', false, true, true, { intent: 'forms_import' })
+    .catch(() => {
+      connecting.value = false
+    })
+}
+
+function issueMessage(reason) {
+  if (reason === 'invalid_url') {
+    return 'Enter a valid URL, for example https://tally.so/r/mBGjOq.'
+  }
+
+  if (reason === 'google_published_url' || reason === 'google_edit_url') {
+    return 'Use the Google Forms edit URL: https://docs.google.com/forms/d/FORM_ID/edit.'
+  }
+
+  if (reason === 'google_unavailable') {
+    return 'Google Forms import is not available in this environment.'
+  }
+
+  if (reason === 'typeform_form_id') {
+    return 'Use a Typeform public URL like https://yourname.typeform.com/to/FORM_ID.'
+  }
+
+  return `This URL is not from ${supportedSourcesLabel.value}.`
+}
+
+function formatSourceList(sources) {
+  if (sources.length <= 1) {
+    return sources[0] || 'a supported source'
+  }
+
+  if (sources.length === 2) {
+    return `${sources[0]} or ${sources[1]}`
+  }
+
+  return `${sources.slice(0, -1).join(', ')}, or ${sources.at(-1)}`
+}
+
+const windowMessage = useWindowMessage(WindowMessageTypes.OAUTH_PROVIDER_CONNECTED)
+onMounted(() => {
+  windowMessage.listen(() => {
+    connecting.value = false
+    oAuth.invalidateProviders()
+  }, {
+    useMessageChannel: false,
+    acknowledge: false,
+  })
+})
 </script>

--- a/client/components/forms/import/FormImportOAuth.vue
+++ b/client/components/forms/import/FormImportOAuth.vue
@@ -1,15 +1,15 @@
 <template>
   <div>
     <!-- Loading providers -->
-    <div v-if="loadingProviders" class="text-center py-8">
+    <div v-if="loadingProviders" class="rounded-lg border border-neutral-200 bg-white py-8 text-center shadow-sm">
       <Loader class="h-6 w-6 mx-auto mb-3" />
-      <p class="text-sm text-gray-500">
+      <p class="text-sm text-neutral-500">
         Checking connection...
       </p>
     </div>
 
     <!-- Has accounts: show account selector -->
-    <div v-else-if="filteredProviders.length">
+    <div v-else-if="filteredProviders.length" class="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
       <FlatSelectInput
         v-model="selectedProviderId"
         :form="form"
@@ -50,14 +50,20 @@
     </div>
 
     <!-- No accounts: show connect prompt -->
-    <div v-else class="text-center py-6">
+    <div v-else class="rounded-lg border border-neutral-200 bg-white px-4 py-7 text-center shadow-sm">
+      <div class="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-lg border border-blue-100 bg-blue-50 text-blue-600">
+        <Icon
+          :name="connectIcon || 'i-heroicons-link'"
+          class="h-5 w-5"
+        />
+      </div>
       <UButton
         :loading="connecting"
         :label="'Connect ' + providerLabel"
         :icon="connectIcon"
         @click="connectProvider"
       />
-      <p class="text-sm text-gray-400 mt-2">
+      <p class="mx-auto mt-3 max-w-sm text-sm leading-6 text-neutral-500">
         {{ connectHelpText }}
       </p>
     </div>

--- a/client/components/forms/import/FormImportSourcePicker.vue
+++ b/client/components/forms/import/FormImportSourcePicker.vue
@@ -1,22 +1,33 @@
 <template>
-  <div class="grid grid-cols-1 sm:grid-cols-3 gap-2">
-    <div
-      v-for="source in sources"
+  <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+    <button
+      v-for="(source, sourceIndex) in sources"
       :key="source.id"
-      role="button"
-      class="rounded-md border p-4 flex h-full flex-col items-center cursor-pointer hover:bg-neutral-50"
+      type="button"
+      class="group flex min-h-30 w-full flex-col justify-between rounded-lg border border-neutral-200 bg-white p-4 text-left shadow-sm transition duration-200 hover:-translate-y-0.5 hover:border-blue-200 hover:shadow-[0_18px_42px_-30px_rgba(37,99,235,0.38)] focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/30"
+      :class="sources.length % 2 === 1 && sourceIndex === sources.length - 1 ? 'sm:col-span-2' : ''"
       @click="$emit('select', source.id)"
     >
-      <div class="flex flex-1 items-center p-2">
-        <UIcon
-          :name="source.icon"
-          :class="source.iconClass"
+      <div class="flex items-start justify-between gap-3">
+        <span
+          class="flex h-10 w-10 items-center justify-center rounded-lg border bg-white shadow-sm"
+          :class="source.iconWrapClass"
+        >
+          <UIcon
+            :name="source.icon"
+            :class="source.iconClass"
+          />
+        </span>
+        <Icon
+          name="i-heroicons-arrow-right"
+          class="mt-1 h-4 w-4 text-neutral-300 transition group-hover:translate-x-0.5 group-hover:text-blue-500"
         />
       </div>
-      <p class="mt-auto font-medium text-center">
-        {{ source.label }}
-      </p>
-    </div>
+      <div class="mt-4">
+        <p class="font-semibold text-neutral-950">{{ source.label }}</p>
+        <p class="mt-1 text-xs leading-5 text-neutral-500">{{ source.description }}</p>
+      </div>
+    </button>
   </div>
 </template>
 
@@ -31,26 +42,34 @@ const allSources = [
   {
     id: 'typeform',
     label: 'Typeform',
+    description: 'Import public Typeform forms from a share URL.',
     icon: 'i-simple-icons-typeform',
-    iconClass: 'w-14 h-14 text-[#262627]',
+    iconClass: 'w-5 h-5 text-[#262627]',
+    iconWrapClass: 'border-neutral-200',
   },
   {
     id: 'tally',
     label: 'Tally',
+    description: 'Bring over a Tally form structure quickly.',
     icon: 'opnform:tally',
-    iconClass: 'w-8 h-8 text-[#725BFF]',
+    iconClass: 'w-5 h-5 text-[#725BFF]',
+    iconWrapClass: 'border-violet-100 bg-violet-50',
   },
   {
     id: 'fillout',
     label: 'Fillout',
+    description: 'Start from an existing Fillout form URL.',
     icon: 'i-simple-icons-fillout',
-    iconClass: 'w-12 h-12 text-[#FFC738]',
+    iconClass: 'w-5 h-5 text-[#FFC738]',
+    iconWrapClass: 'border-amber-100 bg-amber-50',
   },
   {
     id: 'google_forms',
     label: 'Google Forms',
+    description: 'Connect Google and import from an edit URL.',
     icon: 'i-simple-icons-googleforms',
-    iconClass: 'w-10 h-10 text-[#7248B9]',
+    iconClass: 'w-5 h-5 text-[#7248B9]',
+    iconWrapClass: 'border-purple-100 bg-purple-50',
   },
 ]
 

--- a/client/components/forms/import/FormImportUrlInput.vue
+++ b/client/components/forms/import/FormImportUrlInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
     <TextInput
       :form="form"
       name="url"
@@ -8,9 +8,9 @@
       :disabled="loading"
     />
 
-    <p class="text-xs text-gray-500 mt-1.5 flex items-start gap-1">
+    <p class="mt-2 flex items-start gap-1.5 text-xs leading-5 text-neutral-500">
       <Icon
-        name="heroicons:information-circle"
+        name="i-heroicons-information-circle"
         class="w-3.5 h-3.5 mt-0.5 flex-shrink-0"
       />
       <span>{{ helpText }}</span>
@@ -19,8 +19,11 @@
     <UButton
       class="mt-4"
       block
+      icon="i-heroicons-arrow-down-tray"
       :loading="loading"
       :disabled="!form.url"
+      :color="form.url ? 'primary' : 'neutral'"
+      :variant="form.url ? 'solid' : 'soft'"
       :label="buttonLabel"
       @click="$emit('submit')"
     />

--- a/client/components/open/forms/OpenCompleteForm.vue
+++ b/client/components/open/forms/OpenCompleteForm.vue
@@ -276,11 +276,14 @@ const showFormCleanings = computed(() => formManager?.strategy.value.display.sho
 const showFontLink = computed(() => formManager?.strategy.value.display.showFontLink ?? false)
 
 const formStyle = computed(() => {
+  const shouldUseContainerHeight = [FormMode.PREVIEW, FormMode.TEST, FormMode.TEMPLATE].includes(props.mode)
+
   const baseStyle = {
     '--font-family': props.form.font_family,
     'direction': props.form?.layout_rtl ? 'rtl' : 'ltr',
     '--form-color': props.form.color,
-    '--color-form': props.form.color
+    '--color-form': props.form.color,
+    '--form-focused-step-height': shouldUseContainerHeight ? '100%' : '100svh'
   }
 
   // Generate color palette variants

--- a/client/components/open/forms/OpenFormFocused.vue
+++ b/client/components/open/forms/OpenFormFocused.vue
@@ -1,5 +1,5 @@
 <template>
-  <form ref="formElement" v-if="form" @submit.prevent="" class="@container w-full relative overflow-hidden flex flex-col min-h-full">
+  <form ref="formElement" v-if="form" @submit.prevent="" class="@container w-full relative overflow-hidden flex flex-col min-h-full" :style="focusedFormStyle">
     <!-- Fixed fullscreen background from form cover -->
     <div v-if="form.cover_picture" class="absolute inset-0 pointer-events-none">
       <BlockMediaLayout :image="coverMedia" alt="Form cover image" />
@@ -120,6 +120,9 @@ const form = computed(() => props.formManager.config.value)
 const structure = props.formManager.structure
 const state = computed(() => props.formManager.state)
 const isTemplateMode = computed(() => props.formManager?.mode?.value === FormMode.TEMPLATE)
+const focusedFormStyle = {
+  minHeight: 'var(--form-focused-step-height, 100svh)'
+}
 
 const currentIndex = computed(() => state.value.currentPage)
 const currentFields = computed(() => structure?.value?.getPageFields

--- a/client/components/open/forms/components/AIFormLoadingMessages.vue
+++ b/client/components/open/forms/components/AIFormLoadingMessages.vue
@@ -1,97 +1,85 @@
 <template>
-  <div 
-    v-motion
-    :initial="{ opacity: 0, height: 0 }"
-    :enter="{ opacity: 1, height: 52, transition: { duration: 300, ease: 'easeOut' } }"
-    :leave="{ opacity: 0, height: 0, transition: { duration: 300, ease: 'easeIn' } }"
-    class="overflow-hidden w-full"
-  >
-    <div 
-      v-motion
-      :initial="{ opacity: 0, scale: 0.95 }"
-      :enter="{ opacity: 1, scale: 1, transition: { duration: 300 } }"
-      class="flex items-center gap-3 bg-blue-50 px-4 py-3 rounded-lg w-full"
-    >
-      <div 
-        v-motion
-        class="w-7 h-7 rounded-full bg-gradient-to-r from-blue-500 to-blue-300 flex items-center justify-center text-base"
-        :initial="{ rotate: 0 }"
-        :enter="{ 
-          rotate: [-8, 8, -8, 8, 0],
-          transition: { 
-            repeat: Infinity,
-            duration: 1500,
-            ease: 'easeInOut',
-            times: [0, 0.25, 0.5, 0.75, 1]
-          }
-        }"
-      >
-        {{ currentEmoji }}
-      </div>
-      <span 
+  <div class="overflow-hidden">
+    <div class="flex min-w-0 items-center gap-2 rounded-lg border border-blue-100 bg-blue-50 px-3 py-2">
+      <span class="relative flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-white text-blue-600 shadow-sm ring-1 ring-blue-100">
+        <span class="absolute inset-1 rounded-sm border border-blue-200/80 ai-loader-scan" />
+        <Icon
+          :name="currentIcon"
+          class="h-4 w-4"
+        />
+      </span>
+      <span
         :key="currentMessage"
-        v-motion
-        :initial="{ opacity: 0, y: 5 }"
-        :enter="{ opacity: 1, y: 0, transition: { duration: 200 } }"
-        class="text-sm text-neutral-700 font-medium"
+        class="min-w-0 truncate text-sm font-medium text-neutral-700 ai-message-enter"
       >
         {{ currentMessage }}
       </span>
-      <span class="text-xs text-neutral-500 ml-auto tabular-nums">{{ elapsedTime }}s</span>
     </div>
   </div>
 </template>
 
 <script setup>
 const messages = [
-  { text: "Starting AI magic", emoji: "✨" },
-  { text: "Analyzing requirements", emoji: "🤔" },
-  { text: "Designing layout", emoji: "📐" },
-  { text: "Adding form fields", emoji: "📝" },
-  { text: "Fine-tuning validation", emoji: "🎯" },
-  { text: "Optimizing UX", emoji: "💫" },
-  { text: "Adding smart features", emoji: "🧠" },
-  { text: "Polishing design", emoji: "✨" },
-  { text: "Running final checks", emoji: "🔍" },
-  { text: "Almost ready", emoji: "🚀" },
+  { text: "Reading your brief", icon: "i-heroicons-document-magnifying-glass" },
+  { text: "Drafting the question flow", icon: "i-heroicons-queue-list" },
+  { text: "Choosing the right field types", icon: "i-heroicons-squares-plus" },
+  { text: "Shaping validation and copy", icon: "i-heroicons-pencil-square" },
+  { text: "Checking the form structure", icon: "i-heroicons-check-badge" },
+  { text: "Polishing the final draft", icon: "i-heroicons-sparkles" },
 ]
 
 const currentMessage = ref(messages[0].text)
-const currentEmoji = ref(messages[0].emoji)
+const currentIcon = ref(messages[0].icon)
 const messageIndex = ref(0)
-const startTime = ref(Date.now())
-const elapsedTime = ref(0)
 
-// Update message every 2.5 seconds
 const interval = setInterval(() => {
   const nextIndex = (messageIndex.value + 1) % messages.length
   messageIndex.value = nextIndex
   currentMessage.value = messages[nextIndex].text
-  currentEmoji.value = messages[nextIndex].emoji
-}, 2500)
-
-// Update elapsed time every second
-const timeInterval = setInterval(() => {
-  elapsedTime.value = Math.floor((Date.now() - startTime.value) / 1000)
-}, 1000)
+  currentIcon.value = messages[nextIndex].icon
+}, 2600)
 
 onUnmounted(() => {
   clearInterval(interval)
-  clearInterval(timeInterval)
 })
 </script>
 
-<style>
-.animate-shimmer {
-  animation: shimmer 2s infinite linear;
+<style scoped>
+.ai-loader-scan {
+  animation: ai-loader-scan 1.6s ease-in-out infinite;
+  transform-origin: center;
 }
 
-@keyframes shimmer {
+@keyframes ai-loader-scan {
   0% {
-    background-position: 200% 0;
+    opacity: 0.3;
+    transform: scale(0.7) rotate(0deg);
   }
+
+  50% {
+    opacity: 1;
+    transform: scale(1) rotate(12deg);
+  }
+
   100% {
-    background-position: -200% 0;
+    opacity: 0.3;
+    transform: scale(0.7) rotate(0deg);
   }
 }
-</style> 
+
+.ai-message-enter {
+  animation: ai-message-enter 240ms ease-out;
+}
+
+@keyframes ai-message-enter {
+  from {
+    opacity: 0;
+    transform: translateY(3px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+</style>

--- a/client/components/open/forms/components/layouts/SideMediaSplit.vue
+++ b/client/components/open/forms/components/layouts/SideMediaSplit.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full flex z-10 flex-col @3xl:flex-row overflow-hidden">
+  <div class="w-full min-h-full flex z-10 flex-col @3xl:flex-row overflow-hidden">
     <!-- Mobile: media as background on top, content dictates scroll -->
     <div class="relative block @3xl:hidden w-full">
       <!-- Spacer for 50vh visual band -->
@@ -11,19 +11,19 @@
     </div>
 
     <!-- Desktop: media on the left -->
-    <div v-if="isLeft" class="hidden @3xl:block w-1/2 relative overflow-hidden h-[100cqh]">
+    <div v-if="isLeft" class="hidden @3xl:block w-1/2 relative overflow-hidden h-[var(--form-focused-step-height,100svh)]">
       <BlockMediaLayout :image="image" :fallback-height="null" />
     </div>
 
     <!-- Content -->
-    <div class="w-full @3xl:w-1/2 flex items-center px-6">
-      <div class="w-full max-w-2xl mx-auto mt-4 @3xl:mt-0 py-4 @2xl:px-8 @3xl:px-4 @4xl:px-8">
+    <div class="w-full @3xl:w-1/2 flex items-center @3xl:items-start px-6 @3xl:h-[var(--form-focused-step-height,100svh)] @3xl:overflow-y-auto">
+      <div class="w-full max-w-2xl mx-auto mt-4 @3xl:mt-auto @3xl:mb-auto py-4 @2xl:px-8 @3xl:px-4 @4xl:px-8">
         <slot />
       </div>
     </div>
 
     <!-- Desktop: media on the right -->
-    <div v-if="!isLeft" class="hidden @3xl:block w-1/2 relative overflow-hidden h-[100cqh]">
+    <div v-if="!isLeft" class="hidden @3xl:block w-1/2 relative overflow-hidden h-[var(--form-focused-step-height,100svh)]">
       <BlockMediaLayout :image="image" :fallback-height="null" />
     </div>
   </div>
@@ -40,5 +40,3 @@ const props = defineProps({
 
 const isLeft = computed(() => (props.side || 'left') === 'left')
 </script>
-
-

--- a/client/components/pages/forms/create/CreateFormBaseModal.vue
+++ b/client/components/pages/forms/create/CreateFormBaseModal.vue
@@ -1,11 +1,11 @@
 <template>
   <UModal
     v-model:open="isOpen"
-    :ui="{ content: 'sm:max-w-2xl' }"
-    :dismissible="!aiForm.busy"
+    :ui="{ content: 'sm:max-w-3xl overflow-hidden' }"
+    :dismissible="!loading"
   >
     <template #content>
-      <div class="overflow-hidden p-6">
+      <div class="overflow-hidden bg-neutral-50/70 p-2">
         <SlidingTransition
           :style="transitionContainerStyle"
           direction="horizontal"
@@ -20,46 +20,74 @@
             <div
               v-if="currentStep === 1"
               key="step1"
-              class="px-2"
               ref="step1Ref"
+              class="rounded-lg border border-neutral-200 bg-white p-5 shadow-[0_24px_70px_-45px_rgba(15,23,42,0.45)] sm:p-6"
             >
-              <div class="text-center mb-4">
-                <h2 class="text-xl font-bold text-slate-800">Choose a form style</h2>
-                <p class="text-slate-500 text-sm">Choose how your form appears to respondents.<br/>You can change this later.</p>
+              <div class="mx-auto mb-4 max-w-lg text-center">
+                <div class="mx-auto mb-3 flex h-9 w-9 items-center justify-center rounded-lg border border-blue-100 bg-blue-50 text-blue-600">
+                  <Icon
+                    name="i-heroicons-sparkles"
+                    class="h-4 w-4"
+                  />
+                </div>
+                <h2 class="text-xl font-semibold text-neutral-950">Choose a form style</h2>
+                <p class="mt-1 text-sm text-neutral-500">
+                  Pick the respondent experience first. You can still change it later.
+                </p>
               </div>
               <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div
-                  role="button"
+                <button
+                  type="button"
                   data-testid="form-style-classic"
-                  class="group rounded-md border p-6 flex flex-col items-center cursor-pointer hover:bg-neutral-50"
+                  class="group relative overflow-hidden rounded-lg border border-neutral-200 bg-white p-4 text-left shadow-sm transition duration-200 hover:-translate-y-0.5 hover:border-blue-200 hover:shadow-[0_18px_45px_-28px_rgba(37,99,235,0.45)] focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/30"
                   @click="selectStyle('classic')"
                 >
-                  <div class="p-4">
+                  <div class="rounded-lg bg-neutral-50 p-3 ring-1 ring-neutral-100">
                     <Icon
                       name="opnform:form-style-classic"
                       mode="svg"
-                      class="w-[140px] h-[100px] rounded-md shadow **:transition-colors duration-100 ease-out [--icon-fg:#737373] [--icon-muted:#D4D4D4] group-hover:[--icon-fg:#2563eb] group-hover:[--icon-muted:#93c5fd]"
+                      class="mx-auto h-[84px] w-[120px] rounded-md shadow **:transition-colors duration-150 ease-out [--icon-fg:#737373] [--icon-muted:#D4D4D4] group-hover:[--icon-fg:#2563eb] group-hover:[--icon-muted:#93c5fd]"
                     />
                   </div>
-                  <p class="font-medium">Classic</p>
-                  <p class="text-xs text-neutral-500 text-center mt-1">Multiple inputs per page; supports layout blocks and multi-page flows.</p>
-                </div>
-                <div
-                  role="button"
+                  <div class="mt-4 flex items-start justify-between gap-3">
+                    <div>
+                      <p class="font-semibold text-neutral-950">Classic</p>
+                      <p class="mt-1 text-xs leading-5 text-neutral-500">
+                        Multi-page forms with layout blocks.
+                      </p>
+                    </div>
+                    <Icon
+                      name="i-heroicons-arrow-right"
+                      class="mt-1 h-4 w-4 text-neutral-300 transition group-hover:translate-x-0.5 group-hover:text-blue-500"
+                    />
+                  </div>
+                </button>
+                <button
+                  type="button"
                   data-testid="form-style-focused"
-                  class="group rounded-md border p-6 flex flex-col items-center cursor-pointer hover:bg-neutral-50"
+                  class="group relative overflow-hidden rounded-lg border border-neutral-200 bg-white p-4 text-left shadow-sm transition duration-200 hover:-translate-y-0.5 hover:border-blue-200 hover:shadow-[0_18px_45px_-28px_rgba(37,99,235,0.45)] focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/30"
                   @click="selectStyle('focused')"
                 >
-                  <div class="p-4">
+                  <div class="rounded-lg bg-neutral-50 p-3 ring-1 ring-neutral-100">
                     <Icon
                       name="opnform:form-style-focused"
                       mode="svg"
-                      class="w-[140px] h-[100px] rounded-md shadow **:transition-colors duration-100 ease-out [--icon-fg:#737373] [--icon-muted:#D4D4D4] group-hover:[--icon-fg:#2563eb] group-hover:[--icon-muted:#93c5fd]"
+                      class="mx-auto h-[84px] w-[120px] rounded-md shadow **:transition-colors duration-150 ease-out [--icon-fg:#737373] [--icon-muted:#D4D4D4] group-hover:[--icon-fg:#2563eb] group-hover:[--icon-muted:#93c5fd]"
                     />
                   </div>
-                  <p class="font-medium">Focused</p>
-                  <p class="text-xs text-neutral-500 text-center mt-1">Typeform-style: one question per step for a streamlined flow.</p>
-                </div>
+                  <div class="mt-4 flex items-start justify-between gap-3">
+                    <div>
+                      <p class="font-semibold text-neutral-950">Focused</p>
+                      <p class="mt-1 text-xs leading-5 text-neutral-500">
+                        One question at a time.
+                      </p>
+                    </div>
+                    <Icon
+                      name="i-heroicons-arrow-right"
+                      class="mt-1 h-4 w-4 text-neutral-300 transition group-hover:translate-x-0.5 group-hover:text-blue-500"
+                    />
+                  </div>
+                </button>
               </div>
             </div>
 
@@ -67,139 +95,191 @@
             <div
               v-else-if="currentStep === 2"
               key="step2"
-              class="px-2"
               ref="step1Ref"
+              class="rounded-lg border border-neutral-200 bg-white shadow-[0_24px_70px_-45px_rgba(15,23,42,0.45)]"
             >
-              <div class="text-center mb-4">
-                <h2 class="text-xl font-bold text-slate-800">Choose a base for your form</h2>
-              </div>
-              <div class="flex gap-2 mb-2">
+              <div class="flex items-center justify-between gap-3 border-b border-neutral-100 px-4 py-3 sm:px-5">
                 <UButton
                   variant="ghost"
                   color="neutral"
                   icon="i-heroicons-arrow-left"
                   @click="goBackToStep1"
                   label="Back to styles"
+                  class="-ml-2"
                 />
+                <span class="rounded-md border border-neutral-200 bg-neutral-50 px-2 py-1 text-xs font-medium text-neutral-500">
+                  {{ selectedStyleLabel }}
+                </span>
               </div>
-              <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <TrackClick name="select_form_base" :properties="{ base: 'contact-form' }">
-                  <div
-                    role="button"
-                    data-testid="form-base-simple-contact"
-                    class="rounded-md border p-6 flex flex-col items-center cursor-pointer hover:bg-neutral-50"
-                    @click="$emit('close')"
-                  >
-                    <div class="p-4">
-                      <UIcon
-                        name="i-heroicons-envelope"
-                        class="w-8 h-8 text-blue-500"
-                      />
-                    </div>
-                    <p class="font-medium">
-                      Simple contact form
-                    </p>
-                  </div>
-                </TrackClick>
-                <TrackClick v-if="useFeatureFlag('ai_features')" name="select_form_base" :properties="{ base: 'ai' }">
-                  <div
-                    class="rounded-md border p-6 flex flex-col items-center cursor-pointer hover:bg-neutral-50"
-                    role="button"
-                    data-testid="form-base-ai"
-                    @click="currentStep = 3"
-                  >
-                    <div class="p-4">
-                      <UIcon
-                        name="i-heroicons-bolt"
-                        class="w-8 h-8 text-blue-500"
-                      />
-                    </div>
-                    <p class="font-medium text-blue-700">
-                      AI Form Generator
-                    </p>
-                  </div>
-                </TrackClick>
-                <div
-                  class="rounded-md border p-6 flex flex-col items-center cursor-pointer hover:bg-neutral-50 relative"
-                >
-                  <div class="p-4">
-                    <UIcon
-                      name="i-heroicons-squares-2x2"
-                      class="w-8 h-8 text-blue-500"
-                    />
-                  </div>
-                  <p class="font-medium">
-                    Browse templates <Icon name="heroicons:arrow-top-right-on-square-20-solid" class="w-3 h-3 text-neutral-500" />
+
+              <div class="p-4 sm:p-5">
+                <div class="mb-4">
+                  <h2 class="text-xl font-semibold text-neutral-950">How do you want to start?</h2>
+                  <p class="mt-1 text-sm text-neutral-500">
+                    {{ useFeatureFlag('ai_features') ? 'Start from a prompt, a template, an import, or a clean contact form.' : 'Start from a template, an import, or a clean contact form.' }}
                   </p>
-                  <TrackClick name="select_form_base" :properties="{ base: 'template' }">
-                    <NuxtLink
-                      :to="{ name: 'templates' }"
-                      class="absolute inset-0"
-                    />
+                </div>
+
+                <div
+                  v-if="useFeatureFlag('ai_features')"
+                  class="relative overflow-hidden rounded-lg border border-neutral-200 bg-white shadow-[0_20px_55px_-38px_rgba(15,23,42,0.55)]"
+                >
+                  <div class="flex items-center justify-between gap-3 border-b border-neutral-100 bg-neutral-50/80 px-3 py-2">
+                    <div class="flex items-center gap-2">
+                      <span class="flex h-7 w-7 items-center justify-center rounded-md bg-blue-600 text-white shadow-sm">
+                        <Icon
+                          name="i-heroicons-bolt"
+                          class="h-4 w-4"
+                        />
+                      </span>
+                      <div>
+                        <p class="text-sm font-semibold text-neutral-950">AI form generator</p>
+                        <p class="text-xs text-neutral-500">Describe the result you want.</p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <text-area-input
+                    :disabled="loading ? true : null"
+                    :form="aiForm"
+                    name="form_prompt"
+                    placeholder="A lead qualification form for a B2B SaaS demo, with budget, team size, timeline, and a short project brief."
+                    :has-validation="false"
+                    :ui="{
+                      slots: {
+                        input: 'min-h-[150px] resize-none border-0 bg-white px-4 py-4 text-base leading-7 text-neutral-900 shadow-none placeholder:text-neutral-400 focus:border-transparent focus:ring-0 disabled:!bg-white'
+                      }
+                    }"
+                    @input-filled="generateForm"
+                  />
+
+                  <div class="border-t border-neutral-100 px-3 py-3">
+                    <div
+                      v-if="loading"
+                      class="mb-3"
+                    >
+                      <div class="mb-2 flex items-center justify-between gap-3">
+                        <span class="text-xs font-medium text-neutral-600">Generating your form</span>
+                        <span class="text-xs tabular-nums text-neutral-500">{{ Math.round(generationProgress) }}%</span>
+                      </div>
+                      <div class="h-1.5 overflow-hidden rounded-md bg-neutral-100">
+                        <div
+                          class="h-full rounded-md bg-blue-600 transition-[width] duration-500 ease-out"
+                          :style="{ width: `${generationProgress}%` }"
+                        />
+                      </div>
+                    </div>
+
+                    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                      <AIFormLoadingMessages
+                        v-if="loading"
+                        class="min-w-0 flex-1"
+                      />
+                      <div
+                        v-else
+                        class="flex min-w-0 flex-1 items-center gap-2 text-xs text-neutral-500"
+                      >
+                        <Icon
+                          name="i-heroicons-adjustments-horizontal"
+                          class="h-4 w-4 text-neutral-400"
+                        />
+                        <span class="truncate">We will use the {{ selectedStyleLabel.toLowerCase() }} style.</span>
+                      </div>
+
+                      <UButton
+                        data-testid="form-base-ai"
+                        :loading="loading"
+                        :disabled="!hasPrompt || loading"
+                        :color="hasPrompt || loading ? 'primary' : 'neutral'"
+                        :variant="hasPrompt || loading ? 'solid' : 'soft'"
+                        icon="i-heroicons-sparkles"
+                        trailing-icon="i-heroicons-arrow-right"
+                        label="Generate"
+                        class="justify-center"
+                        @click="generateForm"
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                <div class="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+                  <TrackClick name="select_form_base" :properties="{ base: 'contact-form' }">
+                    <button
+                      type="button"
+                      data-testid="form-base-simple-contact"
+                      class="group flex h-full min-h-28 w-full flex-col justify-between rounded-lg border border-neutral-200 bg-white p-4 text-left shadow-sm transition duration-200 hover:-translate-y-0.5 hover:border-blue-200 hover:shadow-[0_18px_42px_-30px_rgba(37,99,235,0.38)] focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/30"
+                      @click="startFromContactForm"
+                    >
+                      <div class="flex items-center justify-between gap-3">
+                        <span class="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
+                          <UIcon
+                            name="i-heroicons-envelope"
+                            class="h-5 w-5"
+                          />
+                        </span>
+                        <Icon
+                          name="i-heroicons-arrow-right"
+                          class="h-4 w-4 text-neutral-300 transition group-hover:translate-x-0.5 group-hover:text-blue-500"
+                        />
+                      </div>
+                      <div class="mt-4">
+                        <p class="font-semibold text-neutral-950">Contact form</p>
+                        <p class="mt-1 text-xs leading-5 text-neutral-500">Name, email, and message.</p>
+                      </div>
+                    </button>
+                  </TrackClick>
+                  <div
+                    class="group relative flex min-h-28 flex-col justify-between rounded-lg border border-neutral-200 bg-white p-4 text-left shadow-sm transition duration-200 hover:-translate-y-0.5 hover:border-amber-200 hover:shadow-[0_18px_42px_-30px_rgba(245,158,11,0.38)]"
+                  >
+                    <div class="flex items-center justify-between gap-3">
+                      <span class="flex h-9 w-9 items-center justify-center rounded-lg bg-amber-50 text-amber-600">
+                        <UIcon
+                          name="i-heroicons-squares-2x2"
+                          class="h-5 w-5"
+                        />
+                      </span>
+                      <Icon
+                        name="i-heroicons-arrow-up-right"
+                        class="h-4 w-4 text-neutral-300 transition group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-amber-600"
+                      />
+                    </div>
+                    <div class="mt-4">
+                      <p class="font-semibold text-neutral-950">Templates</p>
+                      <p class="mt-1 text-xs leading-5 text-neutral-500">Browse proven starting points.</p>
+                    </div>
+                    <TrackClick name="select_form_base" :properties="{ base: 'template' }">
+                      <NuxtLink
+                        :to="{ name: 'templates' }"
+                        aria-label="Browse templates"
+                        class="absolute inset-0"
+                      />
+                    </TrackClick>
+                  </div>
+                  <TrackClick name="select_form_base" :properties="{ base: 'import' }">
+                    <button
+                      type="button"
+                      class="group flex h-full min-h-28 w-full flex-col justify-between rounded-lg border border-neutral-200 bg-white p-4 text-left shadow-sm transition duration-200 hover:-translate-y-0.5 hover:border-emerald-200 hover:shadow-[0_18px_42px_-30px_rgba(16,185,129,0.38)] focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30"
+                      @click="showImportModal = true"
+                    >
+                      <div class="flex items-center justify-between gap-3">
+                        <span class="flex h-9 w-9 items-center justify-center rounded-lg bg-emerald-50 text-emerald-600">
+                          <UIcon
+                            name="i-heroicons-arrow-down-tray"
+                            class="h-5 w-5"
+                          />
+                        </span>
+                        <Icon
+                          name="i-heroicons-arrow-right"
+                          class="h-4 w-4 text-neutral-300 transition group-hover:translate-x-0.5 group-hover:text-emerald-600"
+                        />
+                      </div>
+                      <div class="mt-4">
+                        <p class="font-semibold text-neutral-950">Import</p>
+                        <p class="mt-1 text-xs leading-5 text-neutral-500">{{ importSourcesLabel }}.</p>
+                      </div>
+                    </button>
                   </TrackClick>
                 </div>
-                <TrackClick name="select_form_base" :properties="{ base: 'import' }">
-                  <div
-                    role="button"
-                    class="rounded-md border p-6 flex flex-col items-center cursor-pointer hover:bg-neutral-50"
-                    @click="showImportModal = true"
-                  >
-                    <div class="p-4">
-                      <UIcon
-                        name="i-heroicons-arrow-down-tray"
-                        class="w-8 h-8 text-blue-500"
-                      />
-                    </div>
-                    <p class="font-medium">
-                      Import form
-                    </p>
-                  </div>
-                </TrackClick>
-              </div>
-            </div>
-
-            <!-- Step 3: AI generation -->
-            <div
-              v-else-if="currentStep === 3"
-              key="step3"
-              class="px-2"
-              ref="step1Ref"
-            >
-              <div class="text-center mb-4">
-                <h2 class="text-xl font-bold text-slate-800">AI-powered form generator</h2>
-              </div>
-              <text-area-input
-                label="Form Description"
-                :disabled="loading ? true : null"
-                :form="aiForm"
-                name="form_prompt"
-                help="Give us a description of the form you want to build (the more details the better)"
-                placeholder="A simple contact form, with a name, email and message field"
-              />
-              <UButton
-                class="mt-4"
-                block
-                :loading="loading"
-                @click="generateForm"
-                label="Generate a form"
-              />
-              <p class="text-neutral-500 text-xs text-center mt-1">
-                ~30 sec
-              </p>
-              <div
-                v-if="loading"
-                class="my-4"
-              >
-                <AIFormLoadingMessages />
-              </div>
-              <div class="flex gap-2 mt-4">
-                <UButton
-                  variant="ghost"
-                  color="neutral"
-                  icon="i-heroicons-arrow-left"
-                  @click="currentStep = 2"
-                  label="Back to form types"
-                />
               </div>
             </div>
           </div>
@@ -245,7 +325,7 @@ const isOpen = computed({
   }
 })
 
-// Steps: 1) style, 2) base, 3) ai
+// Steps: 1) style, 2) base
 const currentStep = ref(1)
 const selectedStyle = ref('classic')
 
@@ -254,52 +334,123 @@ const aiForm = useForm({
 })
 const loading = ref(false)
 const showImportModal = ref(false)
+const generationProgress = ref(0)
+const seededFocusedImageUrl = ref(null)
+let generationProgressTimer = null
 
 const transitionDurationMs = 300
 const step1Ref = ref(null)
 const { height: step1Height } = useElementSize(step1Ref)
 const cachedStep1Height = ref(0)
+const cachedStepScrollHeight = ref(0)
 watchEffect(() => {
   if (step1Height?.value) {
     cachedStep1Height.value = step1Height.value
   }
+  if (step1Ref.value) {
+    cachedStepScrollHeight.value = step1Ref.value.scrollHeight
+  }
 })
 const transitionContainerStyle = computed(() => {
-  const h = cachedStep1Height.value
+  const h = Math.max(cachedStep1Height.value, cachedStepScrollHeight.value)
   return h ? { height: h + 'px' } : {}
 })
+
+watch([currentStep, () => props.show], () => {
+  nextTick(() => {
+    if (!step1Ref.value) return
+
+    cachedStep1Height.value = step1Ref.value.offsetHeight
+    cachedStepScrollHeight.value = step1Ref.value.scrollHeight
+  })
+}, { flush: 'post' })
 
 watch(() => props.show, (open) => {
   if (open) {
     currentStep.value = 1
     selectedStyle.value = 'classic'
+    loading.value = false
     showImportModal.value = !!props.defaultImportSource
+    aiForm.form_prompt = ''
+    seededFocusedImageUrl.value = null
+    resetGenerationProgress()
+  } else {
+    loading.value = false
+    showImportModal.value = false
+    seededFocusedImageUrl.value = null
+    resetGenerationProgress()
   }
+})
+
+const hasPrompt = computed(() => {
+  return !!aiForm.form_prompt?.trim()
+})
+
+const { isAuthenticated: authenticated } = useIsAuthenticated()
+const googleImportAvailable = computed(() => {
+  return authenticated.value && !!useFeatureFlag('services.google.auth', false) && !useFeatureFlag('self_hosted', false)
+})
+const importSourcesLabel = computed(() => {
+  return googleImportAvailable.value
+    ? 'Typeform, Tally, Fillout, or Google Forms'
+    : 'Typeform, Tally, or Fillout'
+})
+
+const selectedStyleLabel = computed(() => {
+  return selectedStyle.value === 'focused' ? 'Focused' : 'Classic'
 })
 
 function selectStyle(style) {
   selectedStyle.value = style
-  // Apply immediately to working form
+  applySelectedStyleToWorkingForm()
+  currentStep.value = 2
+}
+
+function applySelectedStyleToWorkingForm() {
   const workingFormStore = useWorkingFormStore()
   if (workingFormStore?.content) {
-    workingFormStore.content.presentation_style = style
-    if (style === 'focused') {
+    workingFormStore.content.presentation_style = selectedStyle.value
+    ensureSettingsObject(workingFormStore.content)
+    if (selectedStyle.value === 'focused') {
       workingFormStore.content.size = 'lg'
-      // Ensure settings object is initialized
-      ensureSettingsObject(workingFormStore.content)
       // Enable navigation arrows by default in focused mode
       workingFormStore.content.settings.navigation_arrows = true
       // Enable auto-next by default in focused mode
       workingFormStore.content.settings.auto_next = true
       // Seed first block image to highlight focused mode
+      const firstBlock = workingFormStore.content.properties?.[0]
+      const hadImageUrl = !!firstBlock?.image?.url
       seedFocusedFirstBlockImage(workingFormStore.content)
+      if (!hadImageUrl && firstBlock?.image?.url) {
+        seededFocusedImageUrl.value = firstBlock.image.url
+      }
+    } else {
+      workingFormStore.content.size = 'md'
+      delete workingFormStore.content.settings.navigation_arrows
+      delete workingFormStore.content.settings.auto_next
+      clearSeededFocusedImage(workingFormStore.content)
     }
   }
-  currentStep.value = 2
+}
+
+function clearSeededFocusedImage(content) {
+  const firstBlock = content?.properties?.[0]
+  if (!seededFocusedImageUrl.value || firstBlock?.image?.url !== seededFocusedImageUrl.value) {
+    seededFocusedImageUrl.value = null
+    return
+  }
+
+  delete firstBlock.image
+  seededFocusedImageUrl.value = null
 }
 
 function goBackToStep1() {
   currentStep.value = 1
+}
+
+function startFromContactForm() {
+  applySelectedStyleToWorkingForm()
+  emit('close')
 }
 
 const handleFormImported = (formData) => {
@@ -309,9 +460,10 @@ const handleFormImported = (formData) => {
 }
 
 const generateForm = () => {
-  if (loading.value) return
+  if (loading.value || !hasPrompt.value) return
 
   loading.value = true
+  startGenerationProgress()
   aiForm
     .post("/forms/ai/generate", {
       body: {
@@ -325,7 +477,7 @@ const generateForm = () => {
     .catch((error) => {
       console.error(error)
       loading.value = false
-      currentStep.value = 3
+      resetGenerationProgress()
     })
 }
 
@@ -341,12 +493,15 @@ const fetchGeneratedForm = (generationId) => {
           if (selectedStyle.value === 'focused') {
             seedFocusedFirstBlockImage(generated)
           }
+          completeGenerationProgress()
+          loading.value = false
           emit("form-generated", generated)
           emit("close")
         } else if (data.ai_form_completion.status === "failed") {
           useAlert().error("Something went wrong, please try again.")
           currentStep.value = 2
           loading.value = false
+          resetGenerationProgress()
         } else {
           fetchGeneratedForm(generationId)
         }
@@ -357,7 +512,47 @@ const fetchGeneratedForm = (generationId) => {
         }
         currentStep.value = 2
         loading.value = false
+        resetGenerationProgress()
       })
   }, 4000)
 }
+
+function startGenerationProgress() {
+  resetGenerationProgress()
+  generationProgress.value = 6
+
+  if (!import.meta.client) return
+
+  const startTime = Date.now()
+  generationProgressTimer = window.setInterval(() => {
+    const elapsed = Date.now() - startTime
+    if (elapsed <= 30000) {
+      generationProgress.value = Math.min(80, 6 + (elapsed / 30000) * 74)
+      return
+    }
+
+    const extraSeconds = (elapsed - 30000) / 1000
+    generationProgress.value = Math.min(95, 80 + Math.log1p(extraSeconds) * 4)
+  }, 350)
+}
+
+function completeGenerationProgress() {
+  stopGenerationProgress()
+  generationProgress.value = 100
+}
+
+function resetGenerationProgress() {
+  stopGenerationProgress()
+  generationProgress.value = 0
+}
+
+function stopGenerationProgress() {
+  if (!generationProgressTimer) return
+  clearInterval(generationProgressTimer)
+  generationProgressTimer = null
+}
+
+onUnmounted(() => {
+  stopGenerationProgress()
+})
 </script>

--- a/client/composables/query/useOAuth.js
+++ b/client/composables/query/useOAuth.js
@@ -84,15 +84,17 @@ export function useOAuth() {
 
   // Queries
   const providers = (options = {}) => {
+    const { requestOptions = {}, ...queryOptions } = options
+
     return useQuery({
       queryKey: ['oauth', 'providers'],
-      queryFn: () => oauthApi.list(options),
+      queryFn: () => oauthApi.list(requestOptions),
       onSuccess: (data) => {
         data?.forEach(provider => {
           queryClient.setQueryData(['oauth', 'providers', provider.id], provider)
         })
       },
-      ...options
+      ...queryOptions
     })
   }
 

--- a/client/lib/forms/detect-form-import-source.js
+++ b/client/lib/forms/detect-form-import-source.js
@@ -1,0 +1,61 @@
+export function normalizeImportUrl(url) {
+  const trimmedUrl = url?.trim() || ''
+
+  if (!trimmedUrl) {
+    return ''
+  }
+
+  if (/^https?:\/\//i.test(trimmedUrl)) {
+    return trimmedUrl
+  }
+
+  return `https://${trimmedUrl}`
+}
+
+export function detectFormImportSource(url) {
+  const normalizedUrl = normalizeImportUrl(url)
+
+  if (!normalizedUrl) {
+    return { source: null, normalizedUrl: '', reason: null }
+  }
+
+  let parsedUrl
+  try {
+    parsedUrl = new URL(normalizedUrl)
+  } catch {
+    return { source: null, normalizedUrl, reason: 'invalid_url' }
+  }
+
+  const host = parsedUrl.hostname.toLowerCase()
+  const path = parsedUrl.pathname
+
+  if (host === 'tally.so') {
+    return { source: 'tally', normalizedUrl, reason: null }
+  }
+
+  if (host === 'fillout.com' || host.endsWith('.fillout.com')) {
+    return { source: 'fillout', normalizedUrl, reason: null }
+  }
+
+  if (host === 'docs.google.com' && path.startsWith('/forms/')) {
+    if (/\/forms\/d\/e\//.test(path)) {
+      return { source: 'google_forms', normalizedUrl, reason: 'google_published_url' }
+    }
+
+    if (!/\/forms\/d\/[a-zA-Z0-9_-]+/.test(path)) {
+      return { source: 'google_forms', normalizedUrl, reason: 'google_edit_url' }
+    }
+
+    return { source: 'google_forms', normalizedUrl, reason: null }
+  }
+
+  if (host === 'typeform.com' || host.endsWith('.typeform.com')) {
+    if (!/\/to\/[a-zA-Z0-9]+/.test(path)) {
+      return { source: 'typeform', normalizedUrl, reason: 'typeform_form_id' }
+    }
+
+    return { source: 'typeform', normalizedUrl, reason: null }
+  }
+
+  return { source: null, normalizedUrl, reason: 'unsupported_provider' }
+}

--- a/client/opnform.config.js
+++ b/client/opnform.config.js
@@ -12,7 +12,7 @@ export default {
     twitter: "https://twitter.com/OpnForm",
     zapier_integration:
       "https://zapier.com/developer/public-invite/146950/58db583730cc46b821614468d94c35de/",
-    book_onboarding: "https://zcal.co/i/YQVGEULQ",
+    book_onboarding: "https://cal.com/julien-nahum/opnform-intro-call",
     feature_requests: "https://feedback.opnform.com/",
     changelog_url: "https://feedback.opnform.com/changelog",
     roadmap: "https://feedback.opnform.com/roadmap",

--- a/client/test/e2e/opnform-flows.spec.ts
+++ b/client/test/e2e/opnform-flows.spec.ts
@@ -271,7 +271,7 @@ async function createFormThroughUi(page: Page, options: { title: string, style: 
   await expect(page.getByText("Choose a form style")).toBeVisible()
 
   await page.getByTestId(options.style === "classic" ? "form-style-classic" : "form-style-focused").click()
-  await expect(page.getByText("Choose a base for your form")).toBeVisible()
+  await expect(page.getByText("How do you want to start?")).toBeVisible()
   await page.getByTestId("form-base-simple-contact").click()
 
   await expect(page.locator("#form-editor")).toBeVisible()

--- a/client/test/unit/detect-form-import-source.test.ts
+++ b/client/test/unit/detect-form-import-source.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { detectFormImportSource, normalizeImportUrl } from '../../lib/forms/detect-form-import-source.js'
+
+describe('normalizeImportUrl', () => {
+  it('adds https when the scheme is omitted', () => {
+    expect(normalizeImportUrl('tally.so/r/mBGjOq')).toBe('https://tally.so/r/mBGjOq')
+  })
+
+  it('keeps existing http schemes', () => {
+    expect(normalizeImportUrl('https://example.typeform.com/to/abc123')).toBe('https://example.typeform.com/to/abc123')
+  })
+})
+
+describe('detectFormImportSource', () => {
+  it('detects Typeform URLs with a form id', () => {
+    expect(detectFormImportSource('example.typeform.com/to/abc123')).toEqual({
+      source: 'typeform',
+      normalizedUrl: 'https://example.typeform.com/to/abc123',
+      reason: null,
+    })
+  })
+
+  it('flags Typeform URLs missing the form id path', () => {
+    expect(detectFormImportSource('https://example.typeform.com/forms/abc123')).toEqual({
+      source: 'typeform',
+      normalizedUrl: 'https://example.typeform.com/forms/abc123',
+      reason: 'typeform_form_id',
+    })
+  })
+
+  it('detects Tally URLs', () => {
+    expect(detectFormImportSource('https://tally.so/r/mBGjOq').source).toBe('tally')
+  })
+
+  it('keeps exact-domain providers aligned with backend validation', () => {
+    expect(detectFormImportSource('https://www.tally.so/r/mBGjOq')).toEqual({
+      source: null,
+      normalizedUrl: 'https://www.tally.so/r/mBGjOq',
+      reason: 'unsupported_provider',
+    })
+  })
+
+  it('detects Fillout URLs and subdomains', () => {
+    expect(detectFormImportSource('https://example.fillout.com/t/abc123').source).toBe('fillout')
+    expect(detectFormImportSource('https://fillout.com/t/abc123').source).toBe('fillout')
+  })
+
+  it('detects Google Forms edit URLs', () => {
+    expect(detectFormImportSource('https://docs.google.com/forms/d/1abc123/edit')).toEqual({
+      source: 'google_forms',
+      normalizedUrl: 'https://docs.google.com/forms/d/1abc123/edit',
+      reason: null,
+    })
+  })
+
+  it('flags published Google Forms URLs', () => {
+    expect(detectFormImportSource('https://docs.google.com/forms/d/e/published123/viewform')).toEqual({
+      source: 'google_forms',
+      normalizedUrl: 'https://docs.google.com/forms/d/e/published123/viewform',
+      reason: 'google_published_url',
+    })
+  })
+
+  it('flags invalid URL text', () => {
+    expect(detectFormImportSource('not a url')).toEqual({
+      source: null,
+      normalizedUrl: 'https://not a url',
+      reason: 'invalid_url',
+    })
+  })
+
+  it('returns unsupported provider for unknown hosts', () => {
+    expect(detectFormImportSource('https://example.com/form')).toEqual({
+      source: null,
+      normalizedUrl: 'https://example.com/form',
+      reason: 'unsupported_provider',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- redesigns the create-form base modal with polished style selection, AI prompt composer, progress feedback, and safer focused/classic state handling
- redesigns form import around a single URL input with automatic provider detection, unsupported URL feedback, and environment-aware Google Forms visibility
- adds legacy Pro grandfathering migration/tests and focused form layout height fixes
- updates onboarding links to the new Cal.com URL

## Validation
- `client: npm run lint`
- `client: npm run test --if-present`
- `api: ./vendor/bin/pest --filter=LegacyProGrandfatheringMigrationTest`
- `api: ./vendor/bin/pint --test`
- `git diff --check`

## Notes
- `api: php artisan test --filter=LegacyProGrandfatheringMigrationTest` was attempted but this Laravel app does not define the `test` artisan command, so Pest was used directly.
- `api: ./vendor/bin/phpstan analyse --memory-limit=2G` currently fails on pre-existing errors in `Console/Commands/Tax/GenerateTaxExport.php` unrelated to this diff.
