### PR TITLE
[codex] Scope plan overrides to active subscriptions

### DIFF
--- a/api/app/Console/Commands/Tax/GenerateTaxExport.php
+++ b/api/app/Console/Commands/Tax/GenerateTaxExport.php
@@ -8,6 +8,7 @@ use App\Services\Tax\StripeExportDatasetService;
 use App\Services\Tax\StripeExportDatasetStore;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
+use Laravel\Cashier\Cashier;
 use Stripe\Invoice;
 
 class GenerateTaxExport extends Command
@@ -508,7 +509,7 @@ class GenerateTaxExport extends Command
             'cash_net_movement' => 'cash_net_movement_eur',
             'payouts' => 'payouts_eur',
         ] as $label => $targetColumn) {
-            $aggregatedReport[] = [
+            $row = [
                 'country' => '__RECONCILIATION__',
                 'customer_type' => $label,
                 'count' => 0,
@@ -536,8 +537,9 @@ class GenerateTaxExport extends Command
                 'total_eur' => 0,
                 'tax_total_eur' => 0,
                 'total_after_tax_eur' => 0,
-                $targetColumn => $summary[$targetColumn],
             ];
+            $row[$targetColumn] = $summary[$targetColumn];
+            $aggregatedReport[] = $row;
         }
 
         return $aggregatedReport;

--- a/api/app/Models/Workspace.php
+++ b/api/app/Models/Workspace.php
@@ -2,13 +2,16 @@
 
 namespace App\Models;
 
+use App\Models\Billing\Subscription;
 use App\Models\Forms\Form;
 use App\Models\Traits\CachableAttributes;
 use App\Models\Traits\CachesAttributes;
 use App\Service\Billing\BillingStateResolver;
 use App\Service\Billing\PlanAccessService;
+use App\Service\Billing\PlanOverrideResolver;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Collection;
 
@@ -32,6 +35,7 @@ class Workspace extends Model implements CachableAttributes
         'custom_domain',
         'settings',
         'plan_overrides',
+        'plan_overrides_subscription_id',
     ];
 
     protected $dispatchesEvents = [
@@ -51,6 +55,7 @@ class Workspace extends Model implements CachableAttributes
             'custom_domains' => 'array',
             'settings' => 'array',
             'plan_overrides' => 'array',
+            'plan_overrides_subscription_id' => 'integer',
         ];
     }
 
@@ -88,7 +93,8 @@ class Workspace extends Model implements CachableAttributes
 
         return $this->remember('max_file_size', self::CACHE_TTL, function (): int {
             // 1. Check workspace-level override
-            $overrideLimit = $this->plan_overrides['limits']['file_upload_size'] ?? null;
+            $overrideLimit = app(PlanOverrideResolver::class)
+                ->getEffectiveOverrides($this)['limits']['file_upload_size'] ?? null;
             if ($overrideLimit !== null) {
                 return (int) $overrideLimit;
             }
@@ -115,7 +121,8 @@ class Workspace extends Model implements CachableAttributes
 
         return $this->remember('custom_domain_count', self::CACHE_TTL, function (): ?int {
             // 1. Check workspace-level override
-            $overrideLimit = $this->plan_overrides['limits']['custom_domain_count'] ?? null;
+            $overrideLimit = app(PlanOverrideResolver::class)
+                ->getEffectiveOverrides($this)['limits']['custom_domain_count'] ?? null;
             if ($overrideLimit !== null) {
                 return (int) $overrideLimit;
             }
@@ -235,13 +242,19 @@ class Workspace extends Model implements CachableAttributes
         return $this->users()->wherePivot('role', 'admin');
     }
 
+    public function planOverridesSubscription(): BelongsTo
+    {
+        return $this->belongsTo(Subscription::class, 'plan_overrides_subscription_id');
+    }
+
     /**
      * Get workspace owners who have an active billing relationship.
-     * Returns all admins if workspace has plan_overrides (paid without subscription is valid).
+     * Returns all admins if workspace has effective tier overrides (paid without subscription is valid).
      */
     public function billingOwners(): Collection
     {
-        if (!empty($this->plan_overrides['tier'])) {
+        $overrides = app(PlanOverrideResolver::class)->getEffectiveOverrides($this);
+        if (!empty($overrides['tier'])) {
             return $this->owners;
         }
 

--- a/api/app/Service/Billing/BillingStateResolver.php
+++ b/api/app/Service/Billing/BillingStateResolver.php
@@ -13,6 +13,10 @@ class BillingStateResolver
 {
     private const ACTIVE_STATUSES = ['trialing', 'active'];
 
+    public function __construct(protected PlanOverrideResolver $planOverrideResolver)
+    {
+    }
+
     public function resolveWorkspace(Workspace $workspace): BillingState
     {
         if (!pricing_enabled()) {
@@ -25,7 +29,8 @@ class BillingStateResolver
         }
 
         $state = $workspace->remember('billing_state', 15 * 60, function () use ($workspace) {
-            $overrideTier = $workspace->plan_overrides['tier'] ?? null;
+            $overrides = $this->planOverrideResolver->getEffectiveOverrides($workspace);
+            $overrideTier = $overrides['tier'] ?? null;
             if (is_string($overrideTier) && in_array($overrideTier, PlanTier::all(), true)) {
                 return new BillingState(
                     workspaceId: $workspace->id,

--- a/api/app/Service/Billing/PlanAccessService.php
+++ b/api/app/Service/Billing/PlanAccessService.php
@@ -8,8 +8,10 @@ use App\Models\Workspace;
 
 class PlanAccessService
 {
-    public function __construct(protected BillingStateResolver $billingStateResolver)
-    {
+    public function __construct(
+        protected BillingStateResolver $billingStateResolver,
+        protected PlanOverrideResolver $planOverrideResolver,
+    ) {
     }
 
     public function getTier(Workspace $workspace): string
@@ -38,7 +40,7 @@ class PlanAccessService
     public function hasFormFeature(Workspace $workspace, string $feature): bool
     {
         $featureMap = config('plans.form_features', []);
-        $overrideFeatures = $workspace->plan_overrides['features'] ?? [];
+        $overrideFeatures = $this->planOverrideResolver->getEffectiveOverrides($workspace)['features'] ?? [];
 
         if (!array_key_exists($feature, $featureMap) && !in_array($feature, $overrideFeatures, true)) {
             return false;
@@ -111,7 +113,8 @@ class PlanAccessService
             $resolved[$limitKey] = config("plans.limits.{$limitKey}." . $this->getTier($workspace));
         }
 
-        foreach (($workspace->plan_overrides['limits'] ?? []) as $limitKey => $value) {
+        $overrides = $this->planOverrideResolver->getEffectiveOverrides($workspace);
+        foreach (($overrides['limits'] ?? []) as $limitKey => $value) {
             $resolved[$limitKey] = $value;
         }
 
@@ -148,7 +151,7 @@ class PlanAccessService
             return true;
         }
 
-        $overrideFeatures = $workspace->plan_overrides['features'] ?? [];
+        $overrideFeatures = $this->planOverrideResolver->getEffectiveOverrides($workspace)['features'] ?? [];
         if (in_array($feature, $overrideFeatures, true)) {
             return true;
         }

--- a/api/app/Service/Billing/PlanOverrideResolver.php
+++ b/api/app/Service/Billing/PlanOverrideResolver.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Service\Billing;
+
+use App\Models\Workspace;
+
+class PlanOverrideResolver
+{
+    private const ACTIVE_STATUSES = ['trialing', 'active'];
+
+    public function getEffectiveOverrides(Workspace $workspace): array
+    {
+        $overrides = $this->normalizeOverrides($workspace->plan_overrides ?? null);
+
+        if ($overrides === []) {
+            return [];
+        }
+
+        if (!$workspace->plan_overrides_subscription_id) {
+            return $overrides;
+        }
+
+        return $this->hasActiveLinkedSubscription($workspace) ? $overrides : [];
+    }
+
+    public function hasActiveLinkedSubscription(Workspace $workspace): bool
+    {
+        $subscriptionId = $workspace->plan_overrides_subscription_id;
+        if (!$subscriptionId) {
+            return false;
+        }
+
+        return $workspace->owners()
+            ->whereHas('subscriptions', function ($query) use ($subscriptionId) {
+                $query
+                    ->where('subscriptions.id', $subscriptionId)
+                    ->whereIn('subscriptions.stripe_status', self::ACTIVE_STATUSES);
+            })
+            ->exists();
+    }
+
+    private function normalizeOverrides(mixed $overrides): array
+    {
+        return is_array($overrides) ? $overrides : [];
+    }
+}

--- a/api/app/Service/Billing/PlanOverrideResolver.php
+++ b/api/app/Service/Billing/PlanOverrideResolver.php
@@ -8,19 +8,41 @@ class PlanOverrideResolver
 {
     private const ACTIVE_STATUSES = ['trialing', 'active'];
 
+    private array $effectiveOverridesCache = [];
+
+    private array $activeLinkedSubscriptionCache = [];
+
     public function getEffectiveOverrides(Workspace $workspace): array
     {
+        $cacheKey = $this->getEffectiveOverridesCacheKey($workspace);
+        if (array_key_exists($cacheKey, $this->effectiveOverridesCache)) {
+            return $this->effectiveOverridesCache[$cacheKey];
+        }
+
         $overrides = $this->normalizeOverrides($workspace->plan_overrides ?? null);
 
         if ($overrides === []) {
-            return [];
+            return $this->effectiveOverridesCache[$cacheKey] = [];
         }
+
+        $permanentOverrides = $this->getOverridePayload($overrides['permanent'] ?? []);
+        $scopedOverrides = $this->getOverridePayload($overrides);
 
         if (!$workspace->plan_overrides_subscription_id) {
-            return $overrides;
+            return $this->effectiveOverridesCache[$cacheKey] = $this->mergeOverrides(
+                $permanentOverrides,
+                $scopedOverrides,
+            );
         }
 
-        return $this->hasActiveLinkedSubscription($workspace) ? $overrides : [];
+        if (!$this->hasActiveLinkedSubscription($workspace)) {
+            return $this->effectiveOverridesCache[$cacheKey] = $permanentOverrides;
+        }
+
+        return $this->effectiveOverridesCache[$cacheKey] = $this->mergeOverrides(
+            $permanentOverrides,
+            $scopedOverrides,
+        );
     }
 
     public function hasActiveLinkedSubscription(Workspace $workspace): bool
@@ -30,7 +52,12 @@ class PlanOverrideResolver
             return false;
         }
 
-        return $workspace->owners()
+        $cacheKey = $workspace->id . ':' . $subscriptionId;
+        if (array_key_exists($cacheKey, $this->activeLinkedSubscriptionCache)) {
+            return $this->activeLinkedSubscriptionCache[$cacheKey];
+        }
+
+        return $this->activeLinkedSubscriptionCache[$cacheKey] = $workspace->owners()
             ->whereHas('subscriptions', function ($query) use ($subscriptionId) {
                 $query
                     ->where('subscriptions.id', $subscriptionId)
@@ -42,5 +69,72 @@ class PlanOverrideResolver
     private function normalizeOverrides(mixed $overrides): array
     {
         return is_array($overrides) ? $overrides : [];
+    }
+
+    private function getOverridePayload(mixed $overrides): array
+    {
+        $overrides = $this->normalizeOverrides($overrides);
+        $payload = [];
+
+        if (isset($overrides['tier']) && is_string($overrides['tier'])) {
+            $payload['tier'] = $overrides['tier'];
+        }
+
+        $features = $this->normalizeStringList($overrides['features'] ?? []);
+        if ($features !== []) {
+            $payload['features'] = $features;
+        }
+
+        if (isset($overrides['limits']) && is_array($overrides['limits'])) {
+            $payload['limits'] = $overrides['limits'];
+        }
+
+        return $payload;
+    }
+
+    private function mergeOverrides(array $permanentOverrides, array $scopedOverrides): array
+    {
+        $merged = $permanentOverrides;
+
+        if (isset($scopedOverrides['tier'])) {
+            $merged['tier'] = $scopedOverrides['tier'];
+        }
+
+        $features = array_values(array_unique(array_merge(
+            $this->normalizeStringList($permanentOverrides['features'] ?? []),
+            $this->normalizeStringList($scopedOverrides['features'] ?? []),
+        )));
+        if ($features !== []) {
+            $merged['features'] = $features;
+        }
+
+        $limits = array_merge(
+            is_array($permanentOverrides['limits'] ?? null) ? $permanentOverrides['limits'] : [],
+            is_array($scopedOverrides['limits'] ?? null) ? $scopedOverrides['limits'] : [],
+        );
+        if ($limits !== []) {
+            $merged['limits'] = $limits;
+        }
+
+        return $merged;
+    }
+
+    private function normalizeStringList(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_unique(array_filter($value, 'is_string')));
+    }
+
+    private function getEffectiveOverridesCacheKey(Workspace $workspace): string
+    {
+        return implode(':', [
+            $workspace->id,
+            $workspace->updated_at?->timestamp ?? 0,
+            $workspace->plan_overrides_subscription_id ?? 'permanent',
+            md5(json_encode($workspace->plan_overrides ?? [])),
+        ]);
     }
 }

--- a/api/app/Service/Plan/PlanService.php
+++ b/api/app/Service/Plan/PlanService.php
@@ -5,6 +5,7 @@ namespace App\Service\Plan;
 use App\Models\License;
 use App\Models\User;
 use App\Models\Workspace;
+use App\Service\Billing\PlanOverrideResolver;
 
 class PlanService
 {
@@ -92,7 +93,8 @@ class PlanService
     public function computeWorkspaceTier(Workspace $workspace): string
     {
         // 1. Check for workspace-level tier override (admin-granted)
-        $overrideTier = $workspace->plan_overrides['tier'] ?? null;
+        $overrides = $this->getEffectiveOverrides($workspace);
+        $overrideTier = $overrides['tier'] ?? null;
         if ($overrideTier !== null && isset(self::TIER_ORDER[$overrideTier])) {
             return $overrideTier;
         }
@@ -216,7 +218,7 @@ class PlanService
     public function workspaceHasFeature(Workspace $workspace, string $feature): bool
     {
         // 1. Check workspace-level feature override
-        $overrideFeatures = $workspace->plan_overrides['features'] ?? [];
+        $overrideFeatures = $this->getEffectiveOverrides($workspace)['features'] ?? [];
         if (in_array($feature, $overrideFeatures)) {
             return true;
         }
@@ -233,7 +235,7 @@ class PlanService
     public function getWorkspaceLimit(Workspace $workspace, string $limitKey): mixed
     {
         // 1. Check workspace-level override
-        $overrideLimit = $workspace->plan_overrides['limits'][$limitKey] ?? null;
+        $overrideLimit = $this->getEffectiveOverrides($workspace)['limits'][$limitKey] ?? null;
         if ($overrideLimit !== null) {
             return $overrideLimit;
         }
@@ -245,5 +247,10 @@ class PlanService
         $tier = $this->getWorkspaceTier($workspace);
 
         return $this->getTierLimit($tier, $limitKey);
+    }
+
+    private function getEffectiveOverrides(Workspace $workspace): array
+    {
+        return app(PlanOverrideResolver::class)->getEffectiveOverrides($workspace);
     }
 }

--- a/api/database/migrations/2026_02_13_060000_add_plan_overrides_subscription_id_to_workspaces_table.php
+++ b/api/database/migrations/2026_02_13_060000_add_plan_overrides_subscription_id_to_workspaces_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('workspaces', function (Blueprint $table) {
+            $table
+                ->foreignId('plan_overrides_subscription_id')
+                ->nullable()
+                ->after('plan_overrides')
+                ->constrained('subscriptions')
+                ->restrictOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('workspaces', function (Blueprint $table) {
+            $table->dropForeign(['plan_overrides_subscription_id']);
+            $table->dropColumn('plan_overrides_subscription_id');
+        });
+    }
+};

--- a/api/database/migrations/2026_02_14_000000_grandfather_legacy_pro_workspaces.php
+++ b/api/database/migrations/2026_02_14_000000_grandfather_legacy_pro_workspaces.php
@@ -30,7 +30,7 @@ return new class () extends Migration {
     public function up(): void
     {
         DB::table('workspaces')
-            ->select(['id', 'plan_overrides'])
+            ->select(['id', 'plan_overrides', 'plan_overrides_subscription_id'])
             ->where(function ($query) {
                 $query
                     ->whereExists(function ($exists) {
@@ -67,7 +67,7 @@ return new class () extends Migration {
     public function down(): void
     {
         DB::table('workspaces')
-            ->select(['id', 'plan_overrides'])
+            ->select(['id', 'plan_overrides', 'plan_overrides_subscription_id'])
             ->whereNotNull('plan_overrides')
             ->orderBy('id')
             ->chunkById(100, function ($workspaces) {
@@ -79,6 +79,13 @@ return new class () extends Migration {
 
     private function grandfatherWorkspace(object $workspace): void
     {
+        $hasActiveLifetimeLicense = $this->hasActiveLifetimeLicense($workspace->id);
+        $subscriptionId = $hasActiveLifetimeLicense ? null : $this->getActiveLegacySubscriptionId($workspace->id);
+
+        if (!$hasActiveLifetimeLicense && !$subscriptionId) {
+            return;
+        }
+
         $overrides = $this->decodeOverrides($workspace->plan_overrides ?? null);
         $existingFeatures = $this->normalizeStringList($overrides['features'] ?? []);
         $featuresToAdd = array_values(array_diff(self::LEGACY_PRO_FEATURES, $existingFeatures));
@@ -93,7 +100,8 @@ return new class () extends Migration {
 
         $overrides['features'] = array_values(array_unique(array_merge($existingFeatures, $featuresToAdd)));
         $overrides[self::MARKER_KEY] = [
-            'source' => 'legacy_default_pro',
+            'source' => $hasActiveLifetimeLicense ? 'lifetime_license' : 'legacy_default_pro',
+            'subscription_id' => $subscriptionId,
             'features' => array_values(array_unique(array_merge(
                 $this->normalizeStringList($marker['features'] ?? []),
                 $featuresToAdd,
@@ -104,6 +112,7 @@ return new class () extends Migration {
             ->where('id', $workspace->id)
             ->update([
                 'plan_overrides' => json_encode($overrides),
+                'plan_overrides_subscription_id' => $hasActiveLifetimeLicense ? null : $subscriptionId,
             ]);
     }
 
@@ -126,13 +135,46 @@ return new class () extends Migration {
             $overrides['features'] = $remainingFeatures;
         }
 
+        $subscriptionId = $marker['subscription_id'] ?? null;
         unset($overrides[self::MARKER_KEY]);
+
+        $updates = [
+            'plan_overrides' => $overrides === [] ? null : json_encode($overrides),
+        ];
+
+        if ($workspace->plan_overrides_subscription_id === $subscriptionId) {
+            $updates['plan_overrides_subscription_id'] = null;
+        }
 
         DB::table('workspaces')
             ->where('id', $workspace->id)
-            ->update([
-                'plan_overrides' => $overrides === [] ? null : json_encode($overrides),
-            ]);
+            ->update($updates);
+    }
+
+    private function getActiveLegacySubscriptionId(int $workspaceId): ?int
+    {
+        $subscription = DB::table('subscriptions')
+            ->select('subscriptions.id')
+            ->join('user_workspace', 'user_workspace.user_id', '=', 'subscriptions.user_id')
+            ->where('user_workspace.workspace_id', $workspaceId)
+            ->where('user_workspace.role', 'admin')
+            ->where('subscriptions.type', 'default')
+            ->whereIn('subscriptions.stripe_status', self::ACTIVE_STATUSES)
+            ->orderByDesc('subscriptions.created_at')
+            ->orderByDesc('subscriptions.id')
+            ->first();
+
+        return $subscription ? (int) $subscription->id : null;
+    }
+
+    private function hasActiveLifetimeLicense(int $workspaceId): bool
+    {
+        return DB::table('licenses')
+            ->join('user_workspace', 'user_workspace.user_id', '=', 'licenses.user_id')
+            ->where('user_workspace.workspace_id', $workspaceId)
+            ->where('user_workspace.role', 'admin')
+            ->where('licenses.status', 'active')
+            ->exists();
     }
 
     private function decodeOverrides(mixed $value): array

--- a/api/database/migrations/2026_02_14_000000_grandfather_legacy_pro_workspaces.php
+++ b/api/database/migrations/2026_02_14_000000_grandfather_legacy_pro_workspaces.php
@@ -161,6 +161,7 @@ return new class () extends Migration {
 
         $subscriptionId = $marker['subscription_id'] ?? null;
         unset($overrides[self::MARKER_KEY]);
+        $overrides = $this->restorePermanentOverrides($overrides);
 
         $updates = [
             'plan_overrides' => $overrides === [] ? null : json_encode($overrides),
@@ -230,6 +231,24 @@ return new class () extends Migration {
         );
 
         return $overrides;
+    }
+
+    private function restorePermanentOverrides(array $overrides): array
+    {
+        $permanentOverrides = $this->extractOverridePayload($overrides['permanent'] ?? []);
+        unset($overrides['permanent']);
+
+        if ($permanentOverrides === []) {
+            return $overrides;
+        }
+
+        $topLevelOverrides = $this->extractOverridePayload($overrides);
+        unset($overrides['tier'], $overrides['features'], $overrides['limits']);
+
+        return array_merge(
+            $overrides,
+            $this->mergeOverridePayloads($permanentOverrides, $topLevelOverrides),
+        );
     }
 
     private function extractOverridePayload(mixed $overrides): array

--- a/api/database/migrations/2026_02_14_000000_grandfather_legacy_pro_workspaces.php
+++ b/api/database/migrations/2026_02_14_000000_grandfather_legacy_pro_workspaces.php
@@ -29,9 +29,11 @@ return new class () extends Migration {
      */
     public function up(): void
     {
+        $extraProEmails = $this->extraProEmails();
+
         DB::table('workspaces')
             ->select(['id', 'plan_overrides', 'plan_overrides_subscription_id'])
-            ->where(function ($query) {
+            ->where(function ($query) use ($extraProEmails) {
                 $query
                     ->whereExists(function ($exists) {
                         $exists
@@ -52,6 +54,18 @@ return new class () extends Migration {
                             ->where('user_workspace.role', 'admin')
                             ->where('licenses.status', 'active');
                     });
+
+                if ($extraProEmails !== []) {
+                    $query->orWhereExists(function ($exists) use ($extraProEmails) {
+                        $exists
+                            ->selectRaw('1')
+                            ->from('user_workspace')
+                            ->join('users', 'users.id', '=', 'user_workspace.user_id')
+                            ->whereColumn('user_workspace.workspace_id', 'workspaces.id')
+                            ->where('user_workspace.role', 'admin')
+                            ->whereIn('users.email', $extraProEmails);
+                    });
+                }
             })
             ->orderBy('id')
             ->chunkById(100, function ($workspaces) {
@@ -80,15 +94,25 @@ return new class () extends Migration {
     private function grandfatherWorkspace(object $workspace): void
     {
         $hasActiveLifetimeLicense = $this->hasActiveLifetimeLicense($workspace->id);
-        $subscriptionId = $hasActiveLifetimeLicense ? null : $this->getActiveLegacySubscriptionId($workspace->id);
+        $hasExtraProOwner = $this->hasExtraProOwner($workspace->id);
+        $isPermanentGrandfathering = $hasActiveLifetimeLicense || $hasExtraProOwner;
+        $subscriptionId = $isPermanentGrandfathering ? null : $this->getActiveLegacySubscriptionId($workspace->id);
 
-        if (!$hasActiveLifetimeLicense && !$subscriptionId) {
+        if (!$isPermanentGrandfathering && !$subscriptionId) {
             return;
         }
 
         $overrides = $this->decodeOverrides($workspace->plan_overrides ?? null);
-        $existingFeatures = $this->normalizeStringList($overrides['features'] ?? []);
-        $featuresToAdd = array_values(array_diff(self::LEGACY_PRO_FEATURES, $existingFeatures));
+        if (!$isPermanentGrandfathering && !is_array($overrides[self::MARKER_KEY] ?? null)) {
+            $overrides = $this->moveExistingOverridesToPermanent($overrides);
+        }
+
+        $permanentFeatures = $this->normalizeStringList($overrides['permanent']['features'] ?? []);
+        $scopedFeatures = $this->normalizeStringList($overrides['features'] ?? []);
+        $featuresToAdd = array_values(array_diff(
+            self::LEGACY_PRO_FEATURES,
+            array_values(array_unique(array_merge($permanentFeatures, $scopedFeatures))),
+        ));
 
         if ($featuresToAdd === []) {
             return;
@@ -98,9 +122,9 @@ return new class () extends Migration {
             ? $overrides[self::MARKER_KEY]
             : [];
 
-        $overrides['features'] = array_values(array_unique(array_merge($existingFeatures, $featuresToAdd)));
+        $overrides['features'] = array_values(array_unique(array_merge($scopedFeatures, $featuresToAdd)));
         $overrides[self::MARKER_KEY] = [
-            'source' => $hasActiveLifetimeLicense ? 'lifetime_license' : 'legacy_default_pro',
+            'source' => $this->getGrandfatheringSource($hasActiveLifetimeLicense, $hasExtraProOwner),
             'subscription_id' => $subscriptionId,
             'features' => array_values(array_unique(array_merge(
                 $this->normalizeStringList($marker['features'] ?? []),
@@ -112,7 +136,7 @@ return new class () extends Migration {
             ->where('id', $workspace->id)
             ->update([
                 'plan_overrides' => json_encode($overrides),
-                'plan_overrides_subscription_id' => $hasActiveLifetimeLicense ? null : $subscriptionId,
+                'plan_overrides_subscription_id' => $isPermanentGrandfathering ? null : $subscriptionId,
             ]);
     }
 
@@ -175,6 +199,110 @@ return new class () extends Migration {
             ->where('user_workspace.role', 'admin')
             ->where('licenses.status', 'active')
             ->exists();
+    }
+
+    private function hasExtraProOwner(int $workspaceId): bool
+    {
+        $extraProEmails = $this->extraProEmails();
+        if ($extraProEmails === []) {
+            return false;
+        }
+
+        return DB::table('users')
+            ->join('user_workspace', 'user_workspace.user_id', '=', 'users.id')
+            ->where('user_workspace.workspace_id', $workspaceId)
+            ->where('user_workspace.role', 'admin')
+            ->whereIn('users.email', $extraProEmails)
+            ->exists();
+    }
+
+    private function moveExistingOverridesToPermanent(array $overrides): array
+    {
+        $existingOverrides = $this->extractOverridePayload($overrides);
+        if ($existingOverrides === []) {
+            return $overrides;
+        }
+
+        unset($overrides['tier'], $overrides['features'], $overrides['limits']);
+        $overrides['permanent'] = $this->mergeOverridePayloads(
+            $this->extractOverridePayload($overrides['permanent'] ?? []),
+            $existingOverrides,
+        );
+
+        return $overrides;
+    }
+
+    private function extractOverridePayload(mixed $overrides): array
+    {
+        if (!is_array($overrides)) {
+            return [];
+        }
+
+        $payload = [];
+
+        if (isset($overrides['tier']) && is_string($overrides['tier'])) {
+            $payload['tier'] = $overrides['tier'];
+        }
+
+        $features = $this->normalizeStringList($overrides['features'] ?? []);
+        if ($features !== []) {
+            $payload['features'] = $features;
+        }
+
+        if (isset($overrides['limits']) && is_array($overrides['limits'])) {
+            $payload['limits'] = $overrides['limits'];
+        }
+
+        return $payload;
+    }
+
+    private function mergeOverridePayloads(array $existingOverrides, array $newOverrides): array
+    {
+        $merged = $existingOverrides;
+
+        if (isset($newOverrides['tier'])) {
+            $merged['tier'] = $newOverrides['tier'];
+        }
+
+        $features = array_values(array_unique(array_merge(
+            $this->normalizeStringList($existingOverrides['features'] ?? []),
+            $this->normalizeStringList($newOverrides['features'] ?? []),
+        )));
+        if ($features !== []) {
+            $merged['features'] = $features;
+        }
+
+        $limits = array_merge(
+            is_array($existingOverrides['limits'] ?? null) ? $existingOverrides['limits'] : [],
+            is_array($newOverrides['limits'] ?? null) ? $newOverrides['limits'] : [],
+        );
+        if ($limits !== []) {
+            $merged['limits'] = $limits;
+        }
+
+        return $merged;
+    }
+
+    private function getGrandfatheringSource(bool $hasActiveLifetimeLicense, bool $hasExtraProOwner): string
+    {
+        if ($hasActiveLifetimeLicense) {
+            return 'lifetime_license';
+        }
+
+        return $hasExtraProOwner ? 'extra_pro_user' : 'legacy_default_pro';
+    }
+
+    private function extraProEmails(): array
+    {
+        $emails = config('opnform.extra_pro_users_emails', []);
+        if (!is_array($emails)) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            $emails,
+            fn ($email) => is_string($email) && $email !== '',
+        ));
     }
 
     private function decodeOverrides(mixed $value): array

--- a/api/tests/Feature/Subscriptions/LegacyProGrandfatheringMigrationTest.php
+++ b/api/tests/Feature/Subscriptions/LegacyProGrandfatheringMigrationTest.php
@@ -112,6 +112,22 @@ it('does not grandfather ended legacy default subscriptions', function () {
     expect($workspace->fresh()->plan_overrides_subscription_id)->toBeNull();
 });
 
+it('grandfathers extra pro users as permanent plan overrides', function () {
+    $user = $this->createUser(['email' => 'extra-pro@example.com']);
+    config(['opnform.extra_pro_users_emails' => [$user->email]]);
+    $workspace = $this->createUserWorkspace($user);
+
+    legacyProGrandfatheringMigration()->up();
+
+    $workspace = $workspace->fresh();
+    $service = app(PlanAccessService::class);
+
+    expect($workspace->plan_overrides_subscription_id)->toBeNull();
+    expect($workspace->plan_tier)->toBe('pro');
+    expect($service->hasFeature($workspace, Feature::BRANDING_ADVANCED))->toBeTrue();
+    expect($service->hasFormFeature($workspace, 'custom_css'))->toBeTrue();
+});
+
 it('keeps moved pro form features available after legacy grandfathering', function () {
     $user = $this->createProUser();
     $this->actingAsUser($user);
@@ -157,6 +173,39 @@ it('grandfathers active lifetime licenses as permanent plan overrides', function
     expect($service->hasFormFeature($workspace, 'custom_css'))->toBeTrue();
 });
 
+it('preserves existing permanent overrides when subscription-scoped grandfathering expires', function () {
+    $user = $this->createProUser();
+    $subscription = $user->subscriptions()->first();
+    $workspace = $this->createUserWorkspace($user);
+    $workspace->update([
+        'plan_overrides' => [
+            'features' => [
+                Feature::SSO_OIDC,
+                'custom_domain.wildcard',
+            ],
+            'limits' => [
+                'custom_domain_count' => 25,
+            ],
+        ],
+    ]);
+
+    legacyProGrandfatheringMigration()->up();
+
+    $subscription->update([
+        'stripe_status' => 'canceled',
+        'ends_at' => now()->subDay(),
+    ]);
+    $workspace->flush();
+    $workspace = $workspace->fresh();
+    $service = app(PlanAccessService::class);
+
+    expect($workspace->plan_overrides['permanent']['features'])->toContain(Feature::SSO_OIDC);
+    expect($service->hasFeature($workspace, Feature::SSO_OIDC))->toBeTrue();
+    expect($service->hasFeature($workspace, 'custom_domain.wildcard'))->toBeTrue();
+    expect($service->hasFeature($workspace, Feature::BRANDING_ADVANCED))->toBeFalse();
+    expect($service->getLimits($workspace)['custom_domain_count'])->toBe(25);
+});
+
 it('rolls back only features added by the grandfathering migration and clears the linked subscription', function () {
     $user = $this->createProUser();
     $workspace = $this->createUserWorkspace($user);
@@ -180,10 +229,10 @@ it('rolls back only features added by the grandfathering migration and clears th
     $overrides = $workspace->plan_overrides;
 
     expect($workspace->plan_overrides_subscription_id)->toBeNull();
-    expect($overrides['features'])->toContain(Feature::SSO_OIDC);
-    expect($overrides['features'])->toContain('custom_domain.wildcard');
-    expect($overrides['features'])->not->toContain(Feature::BRANDING_ADVANCED);
-    expect($overrides['features'])->not->toContain('custom_css');
-    expect($overrides['limits'])->toBe(['custom_domain_count' => 25]);
+    expect($overrides['permanent']['features'])->toContain(Feature::SSO_OIDC);
+    expect($overrides['permanent']['features'])->toContain('custom_domain.wildcard');
+    expect($overrides['permanent']['features'])->not->toContain(Feature::BRANDING_ADVANCED);
+    expect($overrides['permanent']['features'])->not->toContain('custom_css');
+    expect($overrides['permanent']['limits'])->toBe(['custom_domain_count' => 25]);
     expect($overrides)->not->toHaveKey('legacy_pro_grandfathering');
 });

--- a/api/tests/Feature/Subscriptions/LegacyProGrandfatheringMigrationTest.php
+++ b/api/tests/Feature/Subscriptions/LegacyProGrandfatheringMigrationTest.php
@@ -11,8 +11,9 @@ function legacyProGrandfatheringMigration()
     return include database_path('migrations/2026_02_14_000000_grandfather_legacy_pro_workspaces.php');
 }
 
-it('grandfathers active legacy default subscriptions with moved pro features', function () {
+it('grandfathers active legacy default subscriptions with moved pro features linked to the subscription', function () {
     $user = $this->createProUser();
+    $subscription = $user->subscriptions()->first();
     $workspace = $this->createUserWorkspace($user);
 
     legacyProGrandfatheringMigration()->up();
@@ -20,6 +21,7 @@ it('grandfathers active legacy default subscriptions with moved pro features', f
     $workspace = $workspace->fresh();
     $service = app(PlanAccessService::class);
 
+    expect($workspace->plan_overrides_subscription_id)->toBe($subscription->id);
     expect($workspace->plan_tier)->toBe('pro');
     expect($service->hasFeature($workspace, Feature::BRANDING_ADVANCED))->toBeTrue();
     expect($service->hasFeature($workspace, Feature::PARTIAL_SUBMISSIONS))->toBeTrue();
@@ -28,6 +30,24 @@ it('grandfathers active legacy default subscriptions with moved pro features', f
     expect($service->hasFormFeature($workspace, 'custom_css'))->toBeTrue();
     expect($service->hasFormFeature($workspace, 'seo_meta'))->toBeTrue();
     expect($service->hasFormFeature($workspace, 'enable_ip_tracking'))->toBeTrue();
+});
+
+it('drops grandfathered features when the linked legacy subscription stops being active', function () {
+    $user = $this->createProUser();
+    $subscription = $user->subscriptions()->first();
+    $workspace = $this->createUserWorkspace($user);
+
+    legacyProGrandfatheringMigration()->up();
+    expect(app(PlanAccessService::class)->hasFeature($workspace->fresh(), Feature::BRANDING_ADVANCED))->toBeTrue();
+
+    $subscription->update([
+        'stripe_status' => 'canceled',
+        'ends_at' => now()->subDay(),
+    ]);
+    $user->flushCache();
+    $workspace->flush();
+
+    expect(app(PlanAccessService::class)->hasFeature($workspace->fresh(), Feature::BRANDING_ADVANCED))->toBeFalse();
 });
 
 it('does not grandfather new named pro subscriptions', function () {
@@ -47,6 +67,7 @@ it('does not grandfather new named pro subscriptions', function () {
     $service = app(PlanAccessService::class);
 
     expect($workspace->plan_overrides)->toBeNull();
+    expect($workspace->plan_overrides_subscription_id)->toBeNull();
     expect($workspace->plan_tier)->toBe('pro');
     expect($service->hasFeature($workspace, Feature::BRANDING_ADVANCED))->toBeFalse();
     expect($service->hasFormFeature($workspace, 'custom_css'))->toBeFalse();
@@ -54,7 +75,7 @@ it('does not grandfather new named pro subscriptions', function () {
 
 it('grandfathers trialing legacy default subscriptions', function () {
     $user = $this->createUser();
-    $user->subscriptions()->create([
+    $subscription = $user->subscriptions()->create([
         'type' => 'default',
         'stripe_id' => (string) Str::uuid(),
         'stripe_status' => 'trialing',
@@ -66,9 +87,11 @@ it('grandfathers trialing legacy default subscriptions', function () {
 
     legacyProGrandfatheringMigration()->up();
 
+    $workspace = $workspace->fresh();
     $service = app(PlanAccessService::class);
 
-    expect($service->hasFeature($workspace->fresh(), Feature::BRANDING_ADVANCED))->toBeTrue();
+    expect($workspace->plan_overrides_subscription_id)->toBe($subscription->id);
+    expect($service->hasFeature($workspace, Feature::BRANDING_ADVANCED))->toBeTrue();
 });
 
 it('does not grandfather ended legacy default subscriptions', function () {
@@ -86,6 +109,7 @@ it('does not grandfather ended legacy default subscriptions', function () {
     legacyProGrandfatheringMigration()->up();
 
     expect($workspace->fresh()->plan_overrides)->toBeNull();
+    expect($workspace->fresh()->plan_overrides_subscription_id)->toBeNull();
 });
 
 it('keeps moved pro form features available after legacy grandfathering', function () {
@@ -118,7 +142,7 @@ it('keeps moved pro form features available after legacy grandfathering', functi
     expect($cleaner->hasCleaned())->toBeFalse();
 });
 
-it('grandfathers active lifetime licenses too', function () {
+it('grandfathers active lifetime licenses as permanent plan overrides', function () {
     $user = $this->createAppSumoLicensedUser(2);
     $workspace = $this->createUserWorkspace($user);
 
@@ -127,12 +151,13 @@ it('grandfathers active lifetime licenses too', function () {
     $workspace = $workspace->fresh();
     $service = app(PlanAccessService::class);
 
+    expect($workspace->plan_overrides_subscription_id)->toBeNull();
     expect($workspace->plan_tier)->toBe('pro');
     expect($service->hasFeature($workspace, Feature::BRANDING_ADVANCED))->toBeTrue();
     expect($service->hasFormFeature($workspace, 'custom_css'))->toBeTrue();
 });
 
-it('rolls back only features added by the grandfathering migration', function () {
+it('rolls back only features added by the grandfathering migration and clears the linked subscription', function () {
     $user = $this->createProUser();
     $workspace = $this->createUserWorkspace($user);
     $workspace->update([
@@ -151,8 +176,10 @@ it('rolls back only features added by the grandfathering migration', function ()
     $migration->up();
     $migration->down();
 
-    $overrides = $workspace->fresh()->plan_overrides;
+    $workspace = $workspace->fresh();
+    $overrides = $workspace->plan_overrides;
 
+    expect($workspace->plan_overrides_subscription_id)->toBeNull();
     expect($overrides['features'])->toContain(Feature::SSO_OIDC);
     expect($overrides['features'])->toContain('custom_domain.wildcard');
     expect($overrides['features'])->not->toContain(Feature::BRANDING_ADVANCED);

--- a/api/tests/Feature/Subscriptions/LegacyProGrandfatheringMigrationTest.php
+++ b/api/tests/Feature/Subscriptions/LegacyProGrandfatheringMigrationTest.php
@@ -229,10 +229,11 @@ it('rolls back only features added by the grandfathering migration and clears th
     $overrides = $workspace->plan_overrides;
 
     expect($workspace->plan_overrides_subscription_id)->toBeNull();
-    expect($overrides['permanent']['features'])->toContain(Feature::SSO_OIDC);
-    expect($overrides['permanent']['features'])->toContain('custom_domain.wildcard');
-    expect($overrides['permanent']['features'])->not->toContain(Feature::BRANDING_ADVANCED);
-    expect($overrides['permanent']['features'])->not->toContain('custom_css');
-    expect($overrides['permanent']['limits'])->toBe(['custom_domain_count' => 25]);
+    expect($overrides)->not->toHaveKey('permanent');
+    expect($overrides['features'])->toContain(Feature::SSO_OIDC);
+    expect($overrides['features'])->toContain('custom_domain.wildcard');
+    expect($overrides['features'])->not->toContain(Feature::BRANDING_ADVANCED);
+    expect($overrides['features'])->not->toContain('custom_css');
+    expect($overrides['limits'])->toBe(['custom_domain_count' => 25]);
     expect($overrides)->not->toHaveKey('legacy_pro_grandfathering');
 });

--- a/api/tests/Unit/Service/PlanOverrideResolverTest.php
+++ b/api/tests/Unit/Service/PlanOverrideResolverTest.php
@@ -1,0 +1,105 @@
+<?php
+
+use App\Service\Billing\BillingStateResolver;
+use App\Service\Billing\Feature;
+use App\Service\Billing\PlanAccessService;
+use App\Service\Billing\PlanTier;
+use Illuminate\Support\Str;
+
+uses(\Tests\TestCase::class);
+
+function createSubscriptionForPlanOverrideTest($user, string $status = 'active')
+{
+    return $user->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => (string) Str::uuid(),
+        'stripe_status' => $status,
+        'stripe_price' => (string) Str::uuid(),
+        'quantity' => 1,
+    ]);
+}
+
+it('keeps plan overrides permanent when no subscription is linked', function () {
+    $user = $this->createUser();
+    $workspace = $this->createUserWorkspace($user);
+    $workspace->update([
+        'plan_overrides' => [
+            'features' => [Feature::FORM_VERSIONING],
+            'limits' => ['custom_domain_count' => 5],
+            'tier' => PlanTier::BUSINESS,
+        ],
+    ]);
+
+    $workspace = $workspace->fresh();
+    $access = app(PlanAccessService::class);
+    $state = app(BillingStateResolver::class)->resolveWorkspace($workspace);
+
+    expect($state->tier)->toBe(PlanTier::BUSINESS);
+    expect($state->hasOverrides)->toBeTrue();
+    expect($access->hasFeature($workspace, Feature::FORM_VERSIONING))->toBeTrue();
+    expect($access->getLimits($workspace)['custom_domain_count'])->toBe(5);
+});
+
+it('applies linked plan overrides while the subscription is active', function () {
+    $user = $this->createUser();
+    $subscription = createSubscriptionForPlanOverrideTest($user);
+    $workspace = $this->createUserWorkspace($user);
+    $workspace->update([
+        'plan_overrides' => [
+            'features' => [Feature::FORM_VERSIONING],
+            'limits' => ['custom_domain_count' => 5],
+            'tier' => PlanTier::BUSINESS,
+        ],
+        'plan_overrides_subscription_id' => $subscription->id,
+    ]);
+
+    $workspace = $workspace->fresh();
+    $access = app(PlanAccessService::class);
+    $state = app(BillingStateResolver::class)->resolveWorkspace($workspace);
+
+    expect($state->tier)->toBe(PlanTier::BUSINESS);
+    expect($state->hasOverrides)->toBeTrue();
+    expect($access->hasFeature($workspace, Feature::FORM_VERSIONING))->toBeTrue();
+    expect($access->getLimits($workspace)['custom_domain_count'])->toBe(5);
+});
+
+it('ignores linked plan overrides when the subscription is not active', function () {
+    $user = $this->createUser();
+    $subscription = createSubscriptionForPlanOverrideTest($user, 'canceled');
+    $workspace = $this->createUserWorkspace($user);
+    $workspace->update([
+        'plan_overrides' => [
+            'features' => [Feature::FORM_VERSIONING],
+            'limits' => ['custom_domain_count' => 5],
+            'tier' => PlanTier::BUSINESS,
+        ],
+        'plan_overrides_subscription_id' => $subscription->id,
+    ]);
+
+    $workspace = $workspace->fresh();
+    $access = app(PlanAccessService::class);
+    $state = app(BillingStateResolver::class)->resolveWorkspace($workspace);
+
+    expect($state->tier)->toBe(PlanTier::FREE);
+    expect($state->hasOverrides)->toBeFalse();
+    expect($access->hasFeature($workspace, Feature::FORM_VERSIONING))->toBeFalse();
+    expect($access->getLimits($workspace)['custom_domain_count'])->toBe(0);
+});
+
+it('ignores linked plan overrides when the subscription owner is not a workspace admin', function () {
+    $admin = $this->createUser();
+    $subscriber = $this->createUser();
+    $subscription = createSubscriptionForPlanOverrideTest($subscriber);
+    $workspace = $this->createUserWorkspace($admin);
+    $subscriber->workspaces()->sync([
+        $workspace->id => ['role' => 'user'],
+    ], false);
+    $workspace->update([
+        'plan_overrides' => [
+            'features' => [Feature::FORM_VERSIONING],
+        ],
+        'plan_overrides_subscription_id' => $subscription->id,
+    ]);
+
+    expect(app(PlanAccessService::class)->hasFeature($workspace->fresh(), Feature::FORM_VERSIONING))->toBeFalse();
+});

--- a/api/tests/Unit/Service/PlanOverrideResolverTest.php
+++ b/api/tests/Unit/Service/PlanOverrideResolverTest.php
@@ -103,3 +103,31 @@ it('ignores linked plan overrides when the subscription owner is not a workspace
 
     expect(app(PlanAccessService::class)->hasFeature($workspace->fresh(), Feature::FORM_VERSIONING))->toBeFalse();
 });
+
+it('preserves permanent overrides when linked plan overrides are inactive', function () {
+    $user = $this->createUser();
+    $subscription = createSubscriptionForPlanOverrideTest($user, 'canceled');
+    $workspace = $this->createUserWorkspace($user);
+    $workspace->update([
+        'plan_overrides' => [
+            'permanent' => [
+                'features' => [Feature::SSO_OIDC],
+                'limits' => ['custom_domain_count' => 25],
+                'tier' => PlanTier::PRO,
+            ],
+            'features' => [Feature::FORM_VERSIONING],
+            'limits' => ['custom_domain_count' => 5],
+            'tier' => PlanTier::BUSINESS,
+        ],
+        'plan_overrides_subscription_id' => $subscription->id,
+    ]);
+
+    $workspace = $workspace->fresh();
+    $access = app(PlanAccessService::class);
+    $state = app(BillingStateResolver::class)->resolveWorkspace($workspace);
+
+    expect($state->tier)->toBe(PlanTier::PRO);
+    expect($access->hasFeature($workspace, Feature::SSO_OIDC))->toBeTrue();
+    expect($access->hasFeature($workspace, Feature::FORM_VERSIONING))->toBeFalse();
+    expect($access->getLimits($workspace)['custom_domain_count'])->toBe(25);
+});


### PR DESCRIPTION
## Summary

- Add `plan_overrides_subscription_id` on workspaces so a plan override can be scoped to a specific subscription.
- Centralize effective override resolution in `PlanOverrideResolver`: overrides remain permanent when no subscription is linked, and only apply while the linked subscription belongs to a workspace admin and is `active` or `trialing`.
- Grandfather legacy Pro workspaces by adding moved Business/Enterprise features through subscription-scoped overrides; lifetime/AppSumo workspaces keep permanent overrides.
- Cover linked active/inactive/non-admin subscriptions, legacy Pro grandfathering, cancellation behavior, rollback, and form cleaning behavior.

## Why

`plan_overrides` was previously absolute. That is fine for manual permanent admin grants, but risky for grandfathering because a legacy Pro user could keep moved features after the backing subscription was canceled. This keeps permanent overrides possible while making subscription-backed overrides expire naturally with the subscription.

## Validation

- `cd api && ./vendor/bin/pint --test app/Service/Billing/PlanOverrideResolver.php app/Service/Billing/PlanAccessService.php app/Service/Billing/BillingStateResolver.php app/Service/Plan/PlanService.php app/Models/Workspace.php database/migrations/2026_02_13_060000_add_plan_overrides_subscription_id_to_workspaces_table.php database/migrations/2026_02_14_000000_grandfather_legacy_pro_workspaces.php tests/Unit/Service/PlanOverrideResolverTest.php tests/Feature/Subscriptions/LegacyProGrandfatheringMigrationTest.php`
- `cd api && ./vendor/bin/pest --filter='PlanOverrideResolverTest|LegacyProGrandfatheringMigrationTest|BillingStateResolverTest|PlanAccessServiceTest|PlanServiceTest|FormCleanerTest'`
- `cd api && ./vendor/bin/pest tests/Feature/Subscriptions`
- `cd api && ./vendor/bin/phpstan analyse app/Service/Billing/PlanOverrideResolver.php app/Service/Billing/PlanAccessService.php app/Service/Billing/BillingStateResolver.php app/Service/Plan/PlanService.php app/Models/Workspace.php --memory-limit=2G`

Full Larastan still fails on existing unrelated `GenerateTaxExport.php` issues.