### PR TITLE
[codex] Extend exported file link expiration

### DIFF
--- a/api/app/Service/Forms/FormSubmissionFormatter.php
+++ b/api/app/Service/Forms/FormSubmissionFormatter.php
@@ -10,6 +10,8 @@ use Illuminate\Support\Facades\URL;
 
 class FormSubmissionFormatter
 {
+    public const SIGNED_FILE_URL_EXPIRATION_MINUTES = 60 * 24;
+
     /**
      * If true, creates html <a> links for emails and urls
      *
@@ -350,7 +352,7 @@ class FormSubmissionFormatter
 
             return $this->useSignedUrlForFiles ? URL::temporarySignedRoute(
                 'open.forms.submissions.file',
-                now()->addMinutes(config('vapor.signed_storage_url_expires_after', 5)),
+                now()->addMinutes(self::SIGNED_FILE_URL_EXPIRATION_MINUTES),
                 [$formId, $encodedFilename]
             ) : route('open.forms.submissions.file', [$formId, $encodedFilename]);
         } catch (\Exception $e) {

--- a/api/tests/Feature/Forms/FormSubmissionExportTest.php
+++ b/api/tests/Feature/Forms/FormSubmissionExportTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\User;
 use App\Models\Forms\FormSubmission;
+use App\Service\Forms\FormSubmissionFormatter;
 use App\Service\Storage\FileUploadPathService;
 use Illuminate\Support\Facades\Storage;
 
@@ -323,7 +324,7 @@ it('does not include status column when partial submissions are disabled', funct
     expect(str_contains($content, 'status'))->toBeFalse();
 });
 
-it('exports file urls with expiration and a valid signature', function () {
+it('exports file urls with a durable expiration and a valid signature', function () {
     $user = $this->actingAsProUser();
     $workspace = $this->createUserWorkspace($user);
     $form = $this->createForm($user, $workspace, [
@@ -369,6 +370,13 @@ it('exports file urls with expiration and a valid signature', function () {
     parse_str(parse_url($exportedFileUrl, PHP_URL_QUERY), $queryParameters);
 
     expect($queryParameters)->toHaveKeys(['expires', 'signature']);
+    expect((int) $queryParameters['expires'])->toBeGreaterThan(now()->addMinutes(FormSubmissionFormatter::SIGNED_FILE_URL_EXPIRATION_MINUTES - 1)->timestamp);
 
     $this->get($exportedFileUrl)->assertOk();
+
+    $this->travel(6)->minutes();
+
+    $this->get($exportedFileUrl)->assertOk();
+
+    $this->travelBack();
 });


### PR DESCRIPTION
## Summary

- Extend formatter-generated signed file download links from 5 minutes to 24 hours.
- Add an export regression test that verifies the signed file URL remains valid after the old 5-minute failure window.

## Root Cause

Exported CSVs embed signed OpnForm routes for uploaded files and signatures. The previous implementation reused `vapor.signed_storage_url_expires_after`, which is meant for signed upload URLs and is 5 minutes in production. Customers opening exported CSV links after that window hit Laravel's invalid signature response.

## Validation

- `php vendor/bin/pest tests/Feature/Forms/FormSubmissionExportTest.php`
- `php vendor/bin/pest tests/Feature/Forms/FileDownloadSecurityTest.php tests/Feature/Forms/FileDownloadSpecialCharsTest.php`
- `./vendor/bin/pint --test app/Service/Forms/FormSubmissionFormatter.php tests/Feature/Forms/FormSubmissionExportTest.php`
- `git diff --check`