### PR TITLE
[codex] Harden webhook destinations against SSRF

### DIFF
--- a/api/app/Http/Requests/Integration/Zapier/StoreFormZapierWebhookRequest.php
+++ b/api/app/Http/Requests/Integration/Zapier/StoreFormZapierWebhookRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests\Integration\Zapier;
 
 use App\Models\Forms\Form;
 use App\Models\Integration\FormZapierWebhook;
+use App\Rules\PublicWebhookUrlRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class StoreFormZapierWebhookRequest extends FormRequest
@@ -17,7 +18,7 @@ class StoreFormZapierWebhookRequest extends FormRequest
     {
         return [
             'form_slug' => 'required|exists:forms,slug',
-            'hook_url' => 'required|string|url',
+            'hook_url' => ['required', 'string', 'url', new PublicWebhookUrlRule()],
         ];
     }
 

--- a/api/app/Http/Requests/Zapier/CreateIntegrationRequest.php
+++ b/api/app/Http/Requests/Zapier/CreateIntegrationRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Zapier;
 
 use App\Models\Forms\Form;
+use App\Rules\PublicWebhookUrlRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -18,6 +19,7 @@ class CreateIntegrationRequest extends FormRequest
             'hookUrl' => [
                 'required',
                 'url',
+                new PublicWebhookUrlRule(),
             ],
         ];
     }

--- a/api/app/Integrations/Handlers/AbstractIntegrationHandler.php
+++ b/api/app/Integrations/Handlers/AbstractIntegrationHandler.php
@@ -9,6 +9,7 @@ use App\Models\Integration\FormIntegrationsEvent;
 use App\Service\Forms\FormSubmissionFormatter;
 use App\Service\Forms\FormLogicConditionChecker;
 use App\Service\Forms\SubmissionUrlService;
+use App\Service\Security\PublicWebhookUrl;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -98,7 +99,11 @@ abstract class AbstractIntegrationHandler
             return;
         }
 
-        Http::throw()->post($this->getWebhookUrl(), $this->getWebhookData());
+        $url = $this->getWebhookUrl();
+
+        Http::throw()
+            ->withOptions(PublicWebhookUrl::requestOptions($url))
+            ->post($url, $this->getWebhookData());
     }
 
     abstract public static function getValidationRules(?Form $form): array;

--- a/api/app/Integrations/Handlers/ActivepiecesIntegration.php
+++ b/api/app/Integrations/Handlers/ActivepiecesIntegration.php
@@ -3,13 +3,14 @@
 namespace App\Integrations\Handlers;
 
 use App\Models\Forms\Form;
+use App\Rules\PublicWebhookUrlRule;
 
 class ActivepiecesIntegration extends AbstractIntegrationHandler
 {
     public static function getValidationRules(?Form $form): array
     {
         return [
-            'webhook_url' => 'required|url',
+            'webhook_url' => ['required', 'url', new PublicWebhookUrlRule()],
             'provider_url' => 'nullable|url',
         ];
     }

--- a/api/app/Integrations/Handlers/N8nIntegration.php
+++ b/api/app/Integrations/Handlers/N8nIntegration.php
@@ -3,13 +3,14 @@
 namespace App\Integrations\Handlers;
 
 use App\Models\Forms\Form;
+use App\Rules\PublicWebhookUrlRule;
 
 class N8nIntegration extends AbstractIntegrationHandler
 {
     public static function getValidationRules(?Form $form): array
     {
         return [
-            'webhook_url' => 'required|url',
+            'webhook_url' => ['required', 'url', new PublicWebhookUrlRule()],
             'provider_url' => 'nullable|url',
         ];
     }

--- a/api/app/Integrations/Handlers/WebhookIntegration.php
+++ b/api/app/Integrations/Handlers/WebhookIntegration.php
@@ -3,6 +3,8 @@
 namespace App\Integrations\Handlers;
 
 use App\Models\Forms\Form;
+use App\Rules\PublicWebhookUrlRule;
+use App\Service\Security\PublicWebhookUrl;
 use Illuminate\Support\Facades\Http;
 
 class WebhookIntegration extends AbstractIntegrationHandler
@@ -28,7 +30,7 @@ class WebhookIntegration extends AbstractIntegrationHandler
     public static function getValidationRules(?Form $form): array
     {
         return [
-            'webhook_url' => 'required|url',
+            'webhook_url' => ['required', 'url', new PublicWebhookUrlRule()],
             'webhook_secret' => 'nullable|string|min:12',
             'webhook_headers' => [
                 'nullable',
@@ -137,6 +139,7 @@ class WebhookIntegration extends AbstractIntegrationHandler
 
         Http::throw()
             ->timeout(5)
+            ->withOptions(PublicWebhookUrl::requestOptions($this->getWebhookUrl()))
             ->withHeaders($headers)
             ->withBody($payload, 'application/json')
             ->post($this->getWebhookUrl());

--- a/api/app/Models/Integration/FormZapierWebhook.php
+++ b/api/app/Models/Integration/FormZapierWebhook.php
@@ -4,6 +4,7 @@ namespace App\Models\Integration;
 
 use App\Integrations\Handlers\ZapierIntegration;
 use App\Models\Forms\Form;
+use App\Service\Security\PublicWebhookUrl;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Database\Eloquent\Model;
@@ -31,7 +32,7 @@ class FormZapierWebhook extends Model
 
     public function triggerHook(array $data)
     {
-        Http::throw()->post(
+        Http::throw()->withOptions(PublicWebhookUrl::requestOptions($this->hook_url))->post(
             $this->hook_url,
             ZapierIntegration::formatWebhookData($this->form, $data)
         );

--- a/api/app/Rules/PublicWebhookUrlRule.php
+++ b/api/app/Rules/PublicWebhookUrlRule.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Rules;
+
+use App\Service\Security\PublicWebhookUrl;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class PublicWebhookUrlRule implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (!is_string($value)) {
+            $fail('The :attribute must be a valid URL.');
+            return;
+        }
+
+        $message = PublicWebhookUrl::validate($value);
+        if ($message !== null) {
+            $fail($message);
+        }
+    }
+}

--- a/api/app/Service/Security/PublicWebhookUrl.php
+++ b/api/app/Service/Security/PublicWebhookUrl.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace App\Service\Security;
+
+use InvalidArgumentException;
+
+class PublicWebhookUrl
+{
+    public static function assertSafe(string $url): void
+    {
+        self::validatedIp($url);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function requestOptions(string $url): array
+    {
+        $options = [
+            'allow_redirects' => false,
+        ];
+
+        $ip = self::validatedIp($url);
+        if ($ip === null) {
+            return $options;
+        }
+
+        $host = trim((string) parse_url($url, PHP_URL_HOST), '[]');
+        $port = parse_url($url, PHP_URL_PORT) ?: 443;
+
+        $options['curl'] = [
+            CURLOPT_RESOLVE => [
+                sprintf('%s:%d:%s', $host, $port, self::formatCurlResolveIp($ip)),
+            ],
+        ];
+
+        return $options;
+    }
+
+    public static function validate(string $url): ?string
+    {
+        try {
+            self::validatedIp($url);
+        } catch (InvalidArgumentException $e) {
+            return $e->getMessage();
+        }
+
+        return null;
+    }
+
+    private static function validatedIp(string $url): ?string
+    {
+        if (config('opnform.webhooks.allow_private_urls', false)) {
+            self::assertUrlShape($url);
+
+            return null;
+        }
+
+        $shapeError = self::validateUrlShape($url);
+        if ($shapeError !== null) {
+            throw new InvalidArgumentException($shapeError);
+        }
+
+        $host = parse_url($url, PHP_URL_HOST);
+        if (!is_string($host) || $host === '') {
+            throw new InvalidArgumentException('The webhook URL host is invalid.');
+        }
+
+        $ips = self::resolveHost($host);
+        if ($ips === []) {
+            throw new InvalidArgumentException('The webhook URL host could not be resolved.');
+        }
+
+        foreach ($ips as $ip) {
+            if (!self::isPublicIp($ip)) {
+                throw new InvalidArgumentException('The webhook URL must resolve only to public IP addresses.');
+            }
+        }
+
+        return $ips[0];
+    }
+
+    private static function validateUrlShape(string $url): ?string
+    {
+        if (!filter_var($url, FILTER_VALIDATE_URL)) {
+            return 'The webhook URL must be a valid URL.';
+        }
+
+        if (strtolower((string) parse_url($url, PHP_URL_SCHEME)) !== 'https') {
+            return 'The webhook URL must use HTTPS.';
+        }
+
+        if (parse_url($url, PHP_URL_USER) !== null || parse_url($url, PHP_URL_PASS) !== null) {
+            return 'The webhook URL cannot contain embedded credentials.';
+        }
+
+        return null;
+    }
+
+    private static function assertUrlShape(string $url): void
+    {
+        $message = self::validateUrlShape($url);
+
+        if ($message !== null) {
+            throw new InvalidArgumentException($message);
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function resolveHost(string $host): array
+    {
+        $host = trim($host, '[]');
+
+        if (filter_var($host, FILTER_VALIDATE_IP)) {
+            return [$host];
+        }
+
+        if (strtolower(rtrim($host, '.')) === 'localhost') {
+            return ['127.0.0.1'];
+        }
+
+        $records = @dns_get_record($host, DNS_A + DNS_AAAA);
+        if (!is_array($records)) {
+            return [];
+        }
+
+        $ips = [];
+        foreach ($records as $record) {
+            foreach (['ip', 'ipv6'] as $key) {
+                if (isset($record[$key]) && filter_var($record[$key], FILTER_VALIDATE_IP)) {
+                    $ips[] = $record[$key];
+                }
+            }
+        }
+
+        return array_values(array_unique($ips));
+    }
+
+    private static function isPublicIp(string $ip): bool
+    {
+        return filter_var(
+            $ip,
+            FILTER_VALIDATE_IP,
+            FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+        ) !== false;
+    }
+
+    private static function formatCurlResolveIp(string $ip): string
+    {
+        return str_contains($ip, ':') ? '['.$ip.']' : $ip;
+    }
+}

--- a/api/config/opnform.php
+++ b/api/config/opnform.php
@@ -10,4 +10,7 @@ return [
     'custom_code' => [
         'enable_self_hosted' => env('CUSTOM_CODE_ENABLE_SELF_HOSTED', false),
     ],
+    'webhooks' => [
+        'allow_private_urls' => env('WEBHOOKS_ALLOW_PRIVATE_URLS', false),
+    ],
 ];

--- a/api/tests/Feature/Forms/FormIntegrationTest.php
+++ b/api/tests/Feature/Forms/FormIntegrationTest.php
@@ -58,7 +58,7 @@ it('prevents updating another form integration via mismatched form and integrati
         'integration_id' => 'webhook',
         'logic' => null,
         'data' => [
-            'webhook_url' => 'https://victim.example/webhook'
+            'webhook_url' => 'https://example.com/victim-webhook'
         ]
     ])->assertSuccessful();
 
@@ -74,12 +74,12 @@ it('prevents updating another form integration via mismatched form and integrati
         'integration_id' => 'webhook',
         'logic' => null,
         'data' => [
-            'webhook_url' => 'https://attacker.example/steal'
+            'webhook_url' => 'https://example.com/attacker-webhook'
         ]
     ])->assertStatus(404);
 
     $victimIntegration = \App\Models\Integration\FormIntegration::findOrFail((int) $victimIntegrationId);
-    expect($victimIntegration->data->webhook_url)->toBe('https://victim.example/webhook');
+    expect($victimIntegration->data->webhook_url)->toBe('https://example.com/victim-webhook');
 });
 
 it('prevents deleting another form integration via mismatched form and integration ids', function () {
@@ -92,7 +92,7 @@ it('prevents deleting another form integration via mismatched form and integrati
         'integration_id' => 'webhook',
         'logic' => null,
         'data' => [
-            'webhook_url' => 'https://victim.example/webhook'
+            'webhook_url' => 'https://example.com/victim-webhook'
         ]
     ])->assertSuccessful();
 
@@ -207,6 +207,68 @@ it('can create form integration with checkbox logic', function () {
 });
 
 describe('Webhook Integration', function () {
+    it('rejects webhook urls that point to private or metadata addresses', function () {
+        $user = $this->actingAsProUser();
+        $workspace = $this->createUserWorkspace($user);
+        $form = $this->createForm($user, $workspace);
+
+        foreach ([
+            'http://169.254.169.254/latest/meta-data/',
+            'https://169.254.169.254/latest/meta-data/',
+            'https://127.0.0.1/webhook',
+            'https://localhost/webhook',
+            'https://10.0.0.5/webhook',
+        ] as $url) {
+            $this->postJson(route('open.forms.integrations.create', $form), [
+                'status' => 'active',
+                'integration_id' => 'webhook',
+                'logic' => null,
+                'data' => [
+                    'webhook_url' => $url,
+                ],
+            ])
+                ->assertStatus(422)
+                ->assertJsonValidationErrors(['data.webhook_url']);
+        }
+    });
+
+    it('revalidates stored webhook urls before dispatching them', function () {
+        Http::fake();
+
+        $user = $this->actingAsProUser();
+        $workspace = $this->createUserWorkspace($user);
+        $form = $this->createForm($user, $workspace, [
+            'properties' => [
+                [
+                    'id' => 'name',
+                    'name' => 'Name',
+                    'type' => 'text',
+                    'hidden' => false,
+                    'required' => true,
+                ],
+            ],
+        ]);
+
+        $integration = \App\Models\Integration\FormIntegration::factory()
+            ->for($form)
+            ->create([
+                'integration_id' => 'webhook',
+                'status' => \App\Models\Integration\FormIntegration::STATUS_ACTIVE,
+                'data' => [
+                    'webhook_url' => 'https://127.0.0.1/webhook',
+                ],
+            ]);
+
+        $this->postJson(route('forms.answer', $form->slug), $this->generateFormSubmissionData($form))
+            ->assertSuccessful();
+
+        Http::assertNothingSent();
+        $this->assertDatabaseHas('form_integrations_events', [
+            'integration_id' => $integration->id,
+            'status' => \App\Models\Integration\FormIntegrationsEvent::STATUS_ERROR,
+        ]);
+    });
+
     it('includes form and submission ids in the webhook payload', function () {
         Http::fake([
             'https://example.com/*' => Http::response(['ok' => true], 200),

--- a/api/tests/Feature/Security/PublicWebhookUrlTest.php
+++ b/api/tests/Feature/Security/PublicWebhookUrlTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Service\Security\PublicWebhookUrl;
+
+it('pins the validated destination ip for webhook requests', function () {
+    config(['opnform.webhooks.allow_private_urls' => false]);
+
+    $options = PublicWebhookUrl::requestOptions('https://93.184.216.34/webhook');
+
+    expect($options['allow_redirects'])->toBeFalse()
+        ->and($options['curl'][CURLOPT_RESOLVE])->toBe(['93.184.216.34:443:93.184.216.34']);
+});
+
+it('does not pin destinations when private webhook urls are explicitly allowed', function () {
+    config(['opnform.webhooks.allow_private_urls' => true]);
+
+    $options = PublicWebhookUrl::requestOptions('https://127.0.0.1/webhook');
+
+    expect($options)->toBe(['allow_redirects' => false]);
+});
+
+it('rejects link local metadata addresses', function () {
+    config(['opnform.webhooks.allow_private_urls' => false]);
+
+    expect(PublicWebhookUrl::validate('https://169.254.169.254/latest/meta-data/'))
+        ->toBe('The webhook URL must resolve only to public IP addresses.');
+});

--- a/api/tests/Feature/Zapier/IntegrationsTest.php
+++ b/api/tests/Feature/Zapier/IntegrationsTest.php
@@ -54,6 +54,27 @@ test('cannot create an integration without a corresponding ability', function ()
     assertDatabaseCount('form_integrations', 0);
 });
 
+test('cannot create an integration with a private hook url', function () {
+    $user = User::factory()->create();
+    $workspace = createUserWorkspace($user);
+
+    $form = createForm($user, $workspace, ['title' => 'First form']);
+
+    Sanctum::actingAs(
+        $user,
+        ['manage-integrations']
+    );
+
+    post(route('zapier.webhooks.store'), [
+        'form_id' => $form->id,
+        'hookUrl' => 'https://169.254.169.254/latest/meta-data/'
+    ])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('hookUrl');
+
+    assertDatabaseCount('form_integrations', 0);
+});
+
 test('cannot create an integration for other users form', function () {
     $user = User::factory()->create();
 

--- a/docs/api-reference/integrations/create-webhook-integration.mdx
+++ b/docs/api-reference/integrations/create-webhook-integration.mdx
@@ -29,7 +29,7 @@ Configuration object containing webhook details.
 
 <Expandable title="data properties">
 <ParamField body="webhook_url" type="string" required>
-The URL where form submissions will be sent. Must be a valid HTTP/HTTPS URL.
+The URL where form submissions will be sent. Must be a valid HTTPS URL that resolves only to public IP addresses. Private, loopback, link-local, and cloud metadata addresses are rejected.
 </ParamField>
 
 <ParamField body="webhook_secret" type="string">
@@ -112,14 +112,14 @@ curl -X POST 'https://api.opnform.com/open/forms/123/integrations' \
 
 `404 Not Found` – Form not found.
 
-`422 Unprocessable Entity` – Validation error (e.g., invalid webhook URL, webhook_secret too short, blocked header).
+`422 Unprocessable Entity` – Validation error (e.g., invalid or non-public webhook URL, webhook_secret too short, blocked header).
 
 <ResponseExample>
 ```json Error
 {
   "message": "The given data was invalid.",
   "errors": {
-    "data.webhook_url": ["The webhook url must be a valid URL."],
+    "data.webhook_url": ["The webhook URL must use HTTPS."],
     "data.webhook_secret": ["The webhook secret must be at least 12 characters."],
     "data.webhook_headers": ["The 'Authorization' header cannot be customized for security reasons."]
   }
@@ -130,6 +130,8 @@ curl -X POST 'https://api.opnform.com/open/forms/123/integrations' \
 ## Security
 
 If you provide a `webhook_secret` when creating the webhook, OpnForm will sign each webhook request with an HMAC-SHA256 signature. This allows you to verify that the webhook came from OpnForm and hasn't been tampered with.
+
+Webhook URLs are validated when they are saved and again before each delivery. OpnForm does not follow webhook redirects, and private network destinations are blocked unless the instance operator explicitly enables private webhook URLs for a self-hosted deployment.
 
 Each webhook request will include:
 

--- a/docs/api-reference/integrations/update-webhook-integration.mdx
+++ b/docs/api-reference/integrations/update-webhook-integration.mdx
@@ -33,7 +33,7 @@ Configuration object containing webhook details. All fields are optional.
 
 <Expandable title="data properties">
 <ParamField body="webhook_url" type="string">
-The updated URL where form submissions will be sent. Must be a valid HTTP/HTTPS URL.
+The updated URL where form submissions will be sent. Must be a valid HTTPS URL that resolves only to public IP addresses. Private, loopback, link-local, and cloud metadata addresses are rejected.
 </ParamField>
 
 <ParamField body="webhook_secret" type="string">
@@ -108,6 +108,7 @@ curl -X PUT 'https://api.opnform.com/open/forms/123/integrations/42' \
 {
   "message": "The given data was invalid.",
   "errors": {
+    "data.webhook_url": ["The webhook URL must use HTTPS."],
     "data.webhook_secret": ["The webhook secret must be at least 12 characters."],
     "data.webhook_headers": ["The 'Authorization' header cannot be customized for security reasons."]
   }
@@ -116,6 +117,8 @@ curl -X PUT 'https://api.opnform.com/open/forms/123/integrations/42' \
 </ResponseExample>
 
 ## Security
+
+Webhook URLs are validated when they are saved and again before each delivery. OpnForm does not follow webhook redirects, and private network destinations are blocked unless the instance operator explicitly enables private webhook URLs for a self-hosted deployment.
 
 ### Secret Rotation
 


### PR DESCRIPTION
## Summary

Hardens outbound webhook integrations against SSRF by validating webhook destinations at configuration time and immediately before dispatch.

## What changed

- Added a shared `PublicWebhookUrl` validator and Laravel validation rule.
- Require outbound webhook URLs to use HTTPS, omit embedded credentials, resolve successfully, and resolve only to public IP addresses by default.
- Disable redirects for webhook deliveries.
- Pin the validated destination IP with cURL `CURLOPT_RESOLVE` during dispatch to reduce DNS rebinding/TOCTOU risk.
- Applied validation to native webhooks, Zapier webhooks, n8n, and Activepieces integration URLs.
- Added `WEBHOOKS_ALLOW_PRIVATE_URLS` as an explicit self-hosted escape hatch, defaulting to false.
- Updated integration API docs to document the public-HTTPS-only behavior.

## Root cause

Webhook endpoints accepted syntactically valid URLs but did not constrain the resolved destination. A form owner could configure a webhook URL targeting link-local, loopback, private network, or cloud metadata addresses and trigger a server-side request during form submission.

## Impact

Hosted deployments now reject private/reserved webhook destinations and revalidate destinations before delivery. Self-hosted deployments that intentionally post to internal services can opt in with `WEBHOOKS_ALLOW_PRIVATE_URLS=true`.

## Validation

- `cd api && ./vendor/bin/pest tests/Feature/Security/PublicWebhookUrlTest.php tests/Feature/Forms/FormIntegrationTest.php tests/Feature/Zapier/IntegrationsTest.php`
  - 33 passed, 136 assertions
- `cd api && ./vendor/bin/pint --test ...`
  - passed on touched PHP files
- `php -l` on the main touched PHP files
  - passed

Larastan note: `./vendor/bin/phpstan analyse --memory-limit=2G` exhausted memory locally, and `--memory-limit=-1` did not complete in a useful time window. No Larastan result is included from this local run.