### PR TITLE
[codex] Fix signed S3 upload headers

### DIFF
--- a/client/lib/file-uploads.js
+++ b/client/lib/file-uploads.js
@@ -8,6 +8,18 @@ async function storeLocalFile(file) {
   return response
 }
 
+function normalizeSignedStorageHeaders(headers = {}) {
+  return Object.entries(headers).reduce((normalizedHeaders, [name, value]) => {
+    if (name.toLowerCase() === 'host' || value === null || typeof value === 'undefined') {
+      return normalizedHeaders
+    }
+
+    normalizedHeaders[name] = Array.isArray(value) ? value.join(', ') : value
+
+    return normalizedHeaders
+  }, {})
+}
+
 export const storeFile = async (file, options = {}) => {
   if (useFeatureFlag('storage.local'))
     return storeLocalFile(file, options)
@@ -27,6 +39,7 @@ export const storeFile = async (file, options = {}) => {
   await useFetch(response.url, {
     method: "PUT",
     body: file,
+    headers: normalizeSignedStorageHeaders(response.headers),
   })
 
   response.extension = file.name.split(".").pop()

--- a/client/test/unit/file-uploads.test.ts
+++ b/client/test/unit/file-uploads.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { storeFile } from '../../lib/file-uploads.js'
+import { uploadsApi } from '~/api'
+
+vi.mock('~/api', () => ({
+  uploadsApi: {
+    getSignedStorageUrl: vi.fn(),
+    uploadFile: vi.fn(),
+  },
+}))
+
+describe('storeFile', () => {
+  beforeEach(() => {
+    globalThis.useFeatureFlag = vi.fn(() => false)
+    globalThis.useFetch = vi.fn(() => Promise.resolve())
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    delete globalThis.useFeatureFlag
+    delete globalThis.useFetch
+  })
+
+  it('forwards signed storage headers to the S3 PUT request', async () => {
+    const file = {
+      name: 'logo.svg',
+      type: 'image/svg+xml',
+    }
+
+    uploadsApi.getSignedStorageUrl.mockResolvedValue({
+      uuid: '7d438d35-6d81-4317-9bd4-e9c6780b210c',
+      url: 'https://nbg1.your-objectstorage.com/mybucket/tmp/file?X-Amz-SignedHeaders=host%3Bx-amz-acl',
+      headers: {
+        Host: ['nbg1.your-objectstorage.com'],
+        host: ['nbg1.your-objectstorage.com'],
+        'x-amz-acl': ['private'],
+        'Content-Type': 'image/svg+xml',
+      },
+    })
+
+    await storeFile(file)
+
+    expect(globalThis.useFetch).toHaveBeenCalledWith(
+      'https://nbg1.your-objectstorage.com/mybucket/tmp/file?X-Amz-SignedHeaders=host%3Bx-amz-acl',
+      expect.objectContaining({
+        method: 'PUT',
+        body: file,
+        headers: expect.objectContaining({
+          'x-amz-acl': 'private',
+          'Content-Type': 'image/svg+xml',
+        }),
+      }),
+    )
+
+    const uploadOptions = globalThis.useFetch.mock.calls[0][1]
+    expect(uploadOptions.headers).not.toHaveProperty('Host')
+    expect(uploadOptions.headers).not.toHaveProperty('host')
+  })
+})


### PR DESCRIPTION
## Summary
- Forward signed storage headers from `/vapor/signed-storage-url` to the direct S3 PUT request.
- Normalize array header values and skip `Host`, which browsers manage themselves.
- Add a unit regression test for S3-compatible uploads requiring `x-amz-acl`.

## Root Cause
The signed URL endpoint returns headers that are part of the SigV4 signature, including `x-amz-acl`, but `storeFile` only sent `method` and `body` in the browser PUT. S3-compatible providers reject that request with `SignatureDoesNotMatch` when a signed header is missing.

## Validation
- `cd client && npm run test -- test/unit/file-uploads.test.ts`
- `cd client && npm run lint`