### PR TITLE
[codex] Update self-hosted yearly price

### DIFF
--- a/api/config/plans.php
+++ b/api/config/plans.php
@@ -16,7 +16,7 @@ return [
         'pro' => ['order' => 1, 'name' => 'Pro', 'price_monthly' => 29, 'price_yearly' => 299, 'price_yearly_per_month' => 25],
         'business' => ['order' => 2, 'name' => 'Business', 'price_monthly' => 79, 'price_yearly' => 799, 'price_yearly_per_month' => 67],
         'enterprise' => ['order' => 3, 'name' => 'Enterprise', 'price_monthly' => 250, 'price_yearly' => 2640, 'price_yearly_per_month' => 220],
-        'self_hosted' => ['order' => 4, 'name' => 'Self-hosted Enterprise', 'price_monthly' => 199, 'price_yearly' => 1990, 'price_yearly_per_month' => 166],
+        'self_hosted' => ['order' => 4, 'name' => 'Self-hosted Enterprise', 'price_monthly' => 199, 'price_yearly' => 1999, 'price_yearly_per_month' => 167],
     ],
 
     /**

--- a/api/tests/Feature/Content/PlansControllerTest.php
+++ b/api/tests/Feature/Content/PlansControllerTest.php
@@ -5,5 +5,7 @@ it('returns the public plans catalog', function () {
 
     $response->assertSuccessful()
         ->assertJsonPath('tiers.pro.price_monthly', 29)
-        ->assertJsonPath('tiers.enterprise.price_yearly_per_month', 220);
+        ->assertJsonPath('tiers.enterprise.price_yearly_per_month', 220)
+        ->assertJsonPath('tiers.self_hosted.price_yearly', 1999)
+        ->assertJsonPath('tiers.self_hosted.price_yearly_per_month', 167);
 });

--- a/client/pages/pricing.vue
+++ b/client/pages/pricing.vue
@@ -661,7 +661,7 @@
                     <span
                       class="text-3xl sm:text-[40px] sm:leading-12 font-medium tracking-[-1%] text-gray-950"
                     >
-                      $1,990
+                      $1,999
                     </span>
                     <span
                       class="text-base leading-7 tracking-[-1.1%] font-medium text-gray-600"

--- a/client/test/unit/useBillingUpsell.test.ts
+++ b/client/test/unit/useBillingUpsell.test.ts
@@ -18,6 +18,7 @@ describe('useBillingUpsell', () => {
         pro: { order: 1, name: 'Pro', price_monthly: 29, price_yearly_per_month: 25 },
         business: { order: 2, name: 'Business', price_monthly: 79, price_yearly_per_month: 67 },
         enterprise: { order: 3, name: 'Enterprise', price_monthly: 250, price_yearly_per_month: 220 },
+        self_hosted: { order: 4, name: 'Self-hosted Enterprise', price_monthly: 199, price_yearly_per_month: 167 },
       })),
     })
   })
@@ -29,10 +30,12 @@ describe('useBillingUpsell', () => {
     delete globalThis.usePlanCatalog
   })
 
-  it('reads enterprise yearly pricing from the loaded plan catalog', () => {
+  it('reads yearly pricing from the loaded plan catalog', () => {
     const { getPlanPrice, getTierDisplayName } = useBillingUpsell()
 
     expect(getPlanPrice('enterprise', true)).toBe(220)
     expect(getTierDisplayName('enterprise')).toBe('Enterprise')
+    expect(getPlanPrice('self_hosted', true)).toBe(167)
+    expect(getTierDisplayName('self_hosted')).toBe('Self-hosted Enterprise')
   })
 })


### PR DESCRIPTION
## Summary
- update the self-hosted Enterprise annual plan from $1,990/year to $1,999/year
- keep the derived yearly-per-month display value aligned at $167/month
- update pricing-page copy and add API/frontend assertions for the self-hosted price

## Validation
- `./vendor/bin/pest tests/Feature/Content/PlansControllerTest.php`
- `npm run test -- test/unit/useBillingUpsell.test.ts --run`
- `./vendor/bin/pint --test config/plans.php tests/Feature/Content/PlansControllerTest.php`
- `npm run lint`
- `git diff --check`

## Deployment note
Create the Stripe self-hosted yearly price as `$1,999/year` (`unit_amount=199900`) and use that `price_...` ID for `STRIPE_PROD_SELF_HOSTED_PRICING_YEARLY`.
