### PR TITLE
[codex] Bound Stripe tax export window

### DIFF
--- a/api/app/Services/Tax/StripeExportDatasetService.php
+++ b/api/app/Services/Tax/StripeExportDatasetService.php
@@ -63,6 +63,7 @@ class StripeExportDatasetService
             ],
             'status' => 'paid',
             'created' => [
+                'gte' => Carbon::parse($startDate)->subDays($this->getAccountingLookbackDays())->startOfDay()->timestamp,
                 'lte' => Carbon::parse($endDate)->endOfDay()->timestamp,
             ],
         ];
@@ -599,6 +600,7 @@ class StripeExportDatasetService
         $queryOptions = [
             'limit' => 100,
             'created' => [
+                'gte' => Carbon::parse($startDate)->subDays($this->getAccountingLookbackDays())->startOfDay()->timestamp,
                 'lte' => Carbon::parse($endDate)->endOfDay()->timestamp,
             ],
             'expand' => [
@@ -679,6 +681,11 @@ class StripeExportDatasetService
         }
 
         return [];
+    }
+
+    private function getAccountingLookbackDays(): int
+    {
+        return max(0, (int) env('STRIPE_EXPORT_LOOKBACK_DAYS', 45));
     }
 
     private function resolveCustomerId(Invoice $invoice): string


### PR DESCRIPTION
## Summary
- Bound Stripe invoice and charge collection to the requested export month plus a configurable accounting lookback window.
- Added `STRIPE_EXPORT_LOOKBACK_DAYS` support with a 45-day default so monthly exports do not scan the full Stripe account history.

## Root Cause
The accounting-window fix filtered rows by `accounting_ts` after collection, but the Stripe API query only had `created <= endDate`. A monthly export could therefore page through the full historical Stripe invoice and charge set before filtering locally.

## Validation
- `php -l api/app/Services/Tax/StripeExportDatasetService.php`
- Ran April 2026 compta export locally after the equivalent fix: OpnForm completed in 25.89s and generated the expected XLSX + DES files.