### PR TITLE
[codex] Improve phishing spam content detection

### DIFF
--- a/api/app/Service/AI/Prompts/Form/CheckSpamFormPrompt.php
+++ b/api/app/Service/AI/Prompts/Form/CheckSpamFormPrompt.php
@@ -4,6 +4,7 @@ namespace App\Service\AI\Prompts\Form;
 
 use App\Models\Forms\Form;
 use App\Service\AI\Prompts\Prompt;
+use App\Service\Forms\FormSpamContentAnalyzer;
 use Illuminate\Support\Str;
 
 class CheckSpamFormPrompt extends Prompt
@@ -169,17 +170,7 @@ THIS USER HAS BLOCKING HISTORY - READ CAREFULLY:
 
     private function extractFormContent(): string
     {
-        $content = [];
-        $content[] = "Title: " . $this->form->title;
-        $content[] = "Description: " . $this->form->description;
-
-        foreach ($this->form->properties as $field) {
-            $content[] = "- Field Name: " . ($field['name'] ?? 'N/A');
-            $content[] = "  Field Type: " . ($field['type'] ?? 'N/A');
-            $content[] = "  Placeholder: " . ($field['placeholder'] ?? 'N/A');
-        }
-
-        return implode("\n", $content);
+        return (new FormSpamContentAnalyzer())->promptContent($this->form);
     }
 
     private function extractBlockingHistory(): string

--- a/api/app/Service/AI/Prompts/Integration/CheckSpamEmailIntegrationPrompt.php
+++ b/api/app/Service/AI/Prompts/Integration/CheckSpamEmailIntegrationPrompt.php
@@ -5,6 +5,7 @@ namespace App\Service\AI\Prompts\Integration;
 use App\Models\Forms\Form;
 use App\Models\Integration\FormIntegration;
 use App\Service\AI\Prompts\Prompt;
+use App\Service\Forms\FormSpamContentAnalyzer;
 use Illuminate\Support\Str;
 
 class CheckSpamEmailIntegrationPrompt extends Prompt
@@ -29,6 +30,7 @@ class CheckSpamEmailIntegrationPrompt extends Prompt
         Form title: {formTitle}
         Form description: {formDescription}
         Form appears to be default/dummy: {isDefaultForm}
+        Active input fields: {activeInputFields}
         </formContext>
 
         <userInformation>
@@ -110,6 +112,7 @@ class CheckSpamEmailIntegrationPrompt extends Prompt
         $userRegisteredSince = $this->form->creator->created_at->diffInDays(now());
         $isSubscribed = $this->form->creator->is_subscribed ? 'yes' : 'no';
         $isDefaultForm = $this->isDefaultDummyForm() ? 'yes' : 'no';
+        $activeInputFields = (new FormSpamContentAnalyzer())->activeInputFieldCount($this->form);
 
         $blockingHistory = $this->buildBlockingHistoryContext();
 
@@ -121,6 +124,7 @@ class CheckSpamEmailIntegrationPrompt extends Prompt
             ->replace('{linkEditSubmission}', $linkEditSubmission)
             ->replace('{formTitle}', (string) $this->form->title)
             ->replace('{formDescription}', (string) $this->form->description)
+            ->replace('{activeInputFields}', (string) $activeInputFields)
             ->replace('{userRegisteredSince}', (string) $userRegisteredSince)
             ->replace('{isSubscribed}', $isSubscribed)
             ->replace('{isDefaultForm}', $isDefaultForm)
@@ -138,7 +142,7 @@ class CheckSpamEmailIntegrationPrompt extends Prompt
         $hasNoDescription = empty($form->description) || $form->description === '';
 
         // Check if form has very few fields (just the default ones)
-        $defaultFieldCount = count($form->properties ?? []) <= 4;
+        $defaultFieldCount = (new FormSpamContentAnalyzer())->activeInputFieldCount($form) <= 4;
 
         return $isDefaultTitle && $hasNoDescription && $defaultFieldCount;
     }

--- a/api/app/Service/Forms/FormSpamContentAnalyzer.php
+++ b/api/app/Service/Forms/FormSpamContentAnalyzer.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace App\Service\Forms;
+
+use App\Models\Forms\Form;
+use Illuminate\Support\Str;
+
+class FormSpamContentAnalyzer
+{
+    private const FIELD_TEXT_KEYS = [
+        'name',
+        'type',
+        'placeholder',
+        'help',
+        'helpful_text',
+        'content',
+        'image_block',
+        'prefill',
+    ];
+
+    public function keywordScanText(Form $form): string
+    {
+        $parts = [
+            $form->title,
+            $form->description,
+            $form->submit_button_text,
+            $form->submitted_text,
+            $this->collectText($form->seo_meta ?? []),
+        ];
+
+        foreach ($this->visibleProperties($form) as $field) {
+            foreach (self::FIELD_TEXT_KEYS as $key) {
+                if (array_key_exists($key, $field)) {
+                    $parts[] = $this->collectText($field[$key]);
+                }
+            }
+
+            $parts[] = implode(' ', $this->extractUrls($field));
+        }
+
+        return $this->normalizeText(implode(' ', array_filter($parts)));
+    }
+
+    public function promptContent(Form $form): string
+    {
+        $content = [];
+        $content[] = 'Title: ' . $this->normalizeText((string) $form->title);
+        $content[] = 'Description: ' . $this->normalizeText((string) $form->description);
+        $content[] = 'Submit Button: ' . $this->normalizeText((string) $form->submit_button_text);
+        $content[] = 'Submitted Text: ' . $this->summarizeText((string) $form->submitted_text);
+        $content[] = 'Active input fields: ' . $this->activeInputFieldCount($form);
+
+        foreach ($this->visibleProperties($form) as $field) {
+            $content[] = '- Field Name: ' . $this->summarizeText((string) ($field['name'] ?? 'N/A'));
+            $content[] = '  Field Type: ' . $this->summarizeText((string) ($field['type'] ?? 'N/A'));
+
+            if ($this->isDisabled($field)) {
+                $content[] = '  Disabled: yes';
+            }
+
+            foreach (['placeholder', 'help', 'helpful_text', 'content', 'image_block'] as $key) {
+                if (!empty($field[$key])) {
+                    $label = Str::of($key)->replace('_', ' ')->title();
+                    $content[] = "  {$label}: " . $this->summarizeText((string) $field[$key]);
+                }
+            }
+
+            $urls = $this->extractUrls($field);
+            if (!empty($urls)) {
+                $content[] = '  External Links: ' . implode(', ', $urls);
+            }
+        }
+
+        return implode("\n", $content);
+    }
+
+    public function activeInputFieldCount(Form $form): int
+    {
+        return collect($form->properties ?? [])
+            ->filter(fn ($field) => is_array($field) && $this->isActiveInputField($field))
+            ->count();
+    }
+
+    private function visibleProperties(Form $form): array
+    {
+        return collect($form->properties ?? [])
+            ->filter(fn ($field) => is_array($field) && !$this->isHidden($field))
+            ->values()
+            ->all();
+    }
+
+    private function isActiveInputField(array $field): bool
+    {
+        $type = strtolower((string) ($field['type'] ?? ''));
+
+        return $type !== ''
+            && !str_starts_with($type, 'nf-')
+            && !$this->isHidden($field)
+            && !$this->isDisabled($field);
+    }
+
+    private function isHidden(array $field): bool
+    {
+        return filter_var($field['hidden'] ?? false, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    private function isDisabled(array $field): bool
+    {
+        return filter_var($field['disabled'] ?? false, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    private function collectText(mixed $value): string
+    {
+        if (is_string($value)) {
+            return $this->normalizeText($value);
+        }
+
+        if (is_scalar($value)) {
+            return (string) $value;
+        }
+
+        if (is_object($value)) {
+            $value = (array) $value;
+        }
+
+        if (!is_array($value)) {
+            return '';
+        }
+
+        return implode(' ', array_map(fn ($item) => $this->collectText($item), $value));
+    }
+
+    private function normalizeText(string $value): string
+    {
+        $decoded = html_entity_decode($value, ENT_QUOTES | ENT_HTML5);
+        $withoutTags = preg_replace('/<[^>]+>/', ' ', $decoded);
+
+        return trim((string) preg_replace('/\s+/', ' ', $withoutTags));
+    }
+
+    private function summarizeText(string $value): string
+    {
+        return Str::limit($this->normalizeText($value), 1000);
+    }
+
+    private function extractUrls(mixed $value): array
+    {
+        $urls = [];
+
+        foreach ($this->collectRawStrings($value) as $text) {
+            if (preg_match_all('/href\s*=\s*["\']([^"\']+)["\']/i', $text, $matches)) {
+                $urls = array_merge($urls, $matches[1]);
+            }
+
+            if (preg_match_all('~https?://[^\s"\'<>\\\\]+~i', $text, $matches)) {
+                $urls = array_merge($urls, $matches[0]);
+            }
+        }
+
+        return collect($urls)
+            ->map(fn ($url) => rtrim($url, '.,);'))
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    private function collectRawStrings(mixed $value): array
+    {
+        if (is_string($value)) {
+            return [$value];
+        }
+
+        if (is_object($value)) {
+            $value = (array) $value;
+        }
+
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $strings = [];
+        foreach ($value as $item) {
+            $strings = array_merge($strings, $this->collectRawStrings($item));
+        }
+
+        return $strings;
+    }
+}

--- a/api/app/Service/Forms/FormSpamService.php
+++ b/api/app/Service/Forms/FormSpamService.php
@@ -11,13 +11,22 @@ use Illuminate\Support\Facades\Log;
 
 class FormSpamService
 {
-    public function __construct(protected UserActionService $userActionService)
-    {
+    protected FormSpamContentAnalyzer $contentAnalyzer;
+
+    public function __construct(
+        protected UserActionService $userActionService,
+        ?FormSpamContentAnalyzer $contentAnalyzer = null
+    ) {
+        $this->contentAnalyzer = $contentAnalyzer ?? new FormSpamContentAnalyzer();
     }
 
     public function checkForm(Form $form): void
     {
         if (!config('spam.enabled') || !$this->shouldCheck($form)) {
+            return;
+        }
+
+        if (!$this->hasOpenAiApiKey($form)) {
             return;
         }
 
@@ -29,7 +38,7 @@ class FormSpamService
             } elseif ($result['needs_admin_review'] ?? false) {
                 $this->logAdminReview($form, $result['reason'] ?? 'Form flagged for admin review');
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Log::error('Failed to check form for spam.', [
                 'form_id' => $form->id,
                 'exception' => $e->getMessage(),
@@ -70,6 +79,20 @@ class FormSpamService
         return (rand(1, 100) <= config('spam.random_check_percentage', 0));
     }
 
+    private function hasOpenAiApiKey(Form $form): bool
+    {
+        if (!blank(config('services.openai.api_key'))) {
+            return true;
+        }
+
+        Log::warning('Skipping form spam check because OpenAI API key is not configured.', [
+            'form_id' => $form->id,
+            'user_id' => $form->creator?->id,
+        ]);
+
+        return false;
+    }
+
     private function isRiskyUser(User $user): bool
     {
         // Example: Free user registered in the last N days
@@ -78,8 +101,7 @@ class FormSpamService
 
     private function containsKeywords(Form $form): bool
     {
-        $content = json_encode($form->fields) . ' ' . $form->title . ' ' . $form->description;
-        $content = strtolower($content);
+        $content = strtolower($this->contentAnalyzer->keywordScanText($form));
         $keywords = config('spam.keywords', []);
 
         foreach ($keywords as $keyword) {

--- a/api/app/Service/Integrations/EmailIntegrationSpamService.php
+++ b/api/app/Service/Integrations/EmailIntegrationSpamService.php
@@ -22,6 +22,10 @@ class EmailIntegrationSpamService
             return null;
         }
 
+        if (!$this->hasOpenAiApiKey($form, $integration)) {
+            return null;
+        }
+
         try {
             $result = CheckSpamEmailIntegrationPrompt::run($form, $integration);
 
@@ -36,7 +40,7 @@ class EmailIntegrationSpamService
             }
 
             return $result;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Log::error('Failed to check email integration for spam.', [
                 'form_id' => $form->id,
                 'integration_id' => $integration->id,
@@ -102,6 +106,21 @@ class EmailIntegrationSpamService
 
         // Random check for other users
         return (rand(1, 100) <= config('spam.random_check_percentage', 0));
+    }
+
+    private function hasOpenAiApiKey(Form $form, FormIntegration $integration): bool
+    {
+        if (!blank(config('services.openai.api_key'))) {
+            return true;
+        }
+
+        Log::warning('Skipping email integration spam check because OpenAI API key is not configured.', [
+            'form_id' => $form->id,
+            'integration_id' => $integration->id,
+            'user_id' => $form->creator?->id,
+        ]);
+
+        return false;
     }
 
     private function isRiskyUser(User $user): bool

--- a/api/config/spam.php
+++ b/api/config/spam.php
@@ -109,6 +109,12 @@ return [
         "claim your reward",
         "prize winner",
         "lottery winner",
-        "free access"
+        "free access",
+        "voicemail",
+        "click here to listen",
+        "tap here to listen",
+        "click here to continue",
+        "framer.app",
+        "weeblysite.com"
     ],
 ];

--- a/api/tests/Unit/Service/Forms/FormSpamContentAnalyzerTest.php
+++ b/api/tests/Unit/Service/Forms/FormSpamContentAnalyzerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use App\Models\Forms\Form;
+use App\Service\Forms\FormSpamContentAnalyzer;
+
+uses(\Tests\TestCase::class);
+
+function makeSpamAnalyzerForm(array $properties): Form
+{
+    return (new Form())->forceFill([
+        'title' => 'Contact Form',
+        'description' => null,
+        'submit_button_text' => 'Submit',
+        'submitted_text' => '<p>Thanks</p>',
+        'properties' => $properties,
+    ]);
+}
+
+it('scans visible rich content, help links, and image URLs', function () {
+    $form = makeSpamAnalyzerForm([
+        [
+            'id' => 'image',
+            'type' => 'nf-image',
+            'name' => 'Image',
+            'hidden' => false,
+            'image_block' => 'https://api.opnform.com/forms/assets/BT-SPAM.png',
+        ],
+        [
+            'id' => 'text',
+            'type' => 'nf-text',
+            'name' => 'Text',
+            'hidden' => false,
+            'content' => '<p>Securely sign in with your BT email address.</p><p><a href="https://patient-hands-046879.framer.app/">CLICK HERE TO LISTEN</a></p>',
+        ],
+        [
+            'id' => 'hidden',
+            'type' => 'text',
+            'name' => 'Hidden bait',
+            'hidden' => true,
+            'content' => 'this should not be rendered',
+        ],
+    ]);
+
+    $text = (new FormSpamContentAnalyzer())->keywordScanText($form);
+
+    expect($text)
+        ->toContain('Securely sign in with your BT email address')
+        ->toContain('https://patient-hands-046879.framer.app/')
+        ->toContain('https://api.opnform.com/forms/assets/BT-SPAM.png')
+        ->not->toContain('this should not be rendered');
+});
+
+it('counts only active input fields', function () {
+    $form = makeSpamAnalyzerForm([
+        [
+            'id' => 'visible-email',
+            'type' => 'email',
+            'name' => 'Email',
+            'hidden' => false,
+        ],
+        [
+            'id' => 'disabled-url',
+            'type' => 'url',
+            'name' => 'Continue',
+            'hidden' => false,
+            'disabled' => true,
+            'help' => '<a href="https://btmmm-108027.weeblysite.com/">CLICK HERE TO CONTINUE</a>',
+        ],
+        [
+            'id' => 'hidden-text',
+            'type' => 'text',
+            'name' => 'Hidden',
+            'hidden' => true,
+        ],
+        [
+            'id' => 'display-text',
+            'type' => 'nf-text',
+            'name' => 'Instructions',
+            'hidden' => false,
+            'content' => '<p>Visible instructions</p>',
+        ],
+        [
+            'id' => 'visible-rich-text',
+            'type' => 'rich_text',
+            'name' => 'Message',
+            'hidden' => false,
+        ],
+    ]);
+
+    expect((new FormSpamContentAnalyzer())->activeInputFieldCount($form))->toBe(2);
+});
+
+it('keeps disabled visible help in the prompt without counting it as active', function () {
+    $form = makeSpamAnalyzerForm([
+        [
+            'id' => 'disabled-url',
+            'type' => 'url',
+            'name' => '*',
+            'hidden' => false,
+            'disabled' => true,
+            'help' => '<a href="https://btmmm-108027.weeblysite.com/">CLICK HERE TO CONTINUE</a>',
+        ],
+    ]);
+
+    $promptContent = (new FormSpamContentAnalyzer())->promptContent($form);
+
+    expect($promptContent)
+        ->toContain('Active input fields: 0')
+        ->toContain('Disabled: yes')
+        ->toContain('CLICK HERE TO CONTINUE')
+        ->toContain('https://btmmm-108027.weeblysite.com/');
+});

--- a/api/tests/Unit/Service/Forms/FormSpamServiceTest.php
+++ b/api/tests/Unit/Service/Forms/FormSpamServiceTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use App\Models\Forms\Form;
+use App\Models\User;
+use App\Service\Forms\FormSpamContentAnalyzer;
+use App\Service\Forms\FormSpamService;
+use App\Service\UserActionService;
+
+uses(\Tests\TestCase::class);
+
+it('checks spam keywords against real form properties instead of the missing fields attribute', function () {
+    config()->set('spam.keywords', ['sign in']);
+
+    $form = (new Form())->forceFill([
+        'title' => 'Contact Form',
+        'description' => null,
+        'properties' => [
+            [
+                'id' => 'text',
+                'type' => 'nf-text',
+                'name' => 'Text',
+                'hidden' => false,
+                'content' => '<p>Securely sign in with your BT email address.</p>',
+            ],
+        ],
+    ]);
+
+    $service = new FormSpamService(new UserActionService(), new FormSpamContentAnalyzer());
+    $method = new ReflectionMethod(FormSpamService::class, 'containsKeywords');
+    $method->setAccessible(true);
+
+    expect($method->invoke($service, $form))->toBeTrue();
+});
+
+it('skips ai spam checks when the openai key is missing', function () {
+    config()->set('opnform.admin_emails', []);
+    config()->set('opnform.moderator_emails', []);
+    config()->set('services.openai.api_key', null);
+    config()->set('spam.enabled', true);
+    config()->set('spam.keywords', ['sign in']);
+
+    $creator = (new User())->forceFill([
+        'id' => 123,
+        'name' => 'Test User',
+        'email' => 'spam-check-ci@example.test',
+        'created_at' => now(),
+        'blocked_at' => null,
+        'meta' => [],
+    ]);
+
+    $form = (new Form())->forceFill([
+        'id' => 456,
+        'title' => 'Contact Form',
+        'properties' => [
+            [
+                'id' => 'text',
+                'type' => 'nf-text',
+                'name' => 'Text',
+                'hidden' => false,
+                'content' => '<p>Securely sign in with your BT email address.</p>',
+            ],
+        ],
+    ]);
+    $form->setRelation('creator', $creator);
+
+    $userActionService = Mockery::mock(UserActionService::class);
+    $userActionService->shouldNotReceive('block');
+
+    (new FormSpamService($userActionService, new FormSpamContentAnalyzer()))->checkForm($form);
+
+    expect(true)->toBeTrue();
+});

--- a/api/tests/Unit/Service/Integrations/CheckSpamEmailIntegrationPromptTest.php
+++ b/api/tests/Unit/Service/Integrations/CheckSpamEmailIntegrationPromptTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Models\Forms\Form;
+use App\Models\Integration\FormIntegration;
+use App\Service\AI\Prompts\Integration\CheckSpamEmailIntegrationPrompt;
+
+uses(\Tests\TestCase::class);
+
+it('treats default forms with only hidden, disabled, or display blocks as dummy forms', function () {
+    $form = (new Form())->forceFill([
+        'title' => 'Contact Form',
+        'description' => null,
+        'properties' => [
+            [
+                'id' => 'disabled-url',
+                'type' => 'url',
+                'name' => 'Continue',
+                'disabled' => true,
+                'hidden' => false,
+            ],
+            [
+                'id' => 'hidden-email',
+                'type' => 'email',
+                'name' => 'Email',
+                'hidden' => true,
+            ],
+            [
+                'id' => 'image',
+                'type' => 'nf-image',
+                'name' => 'Image',
+                'hidden' => false,
+            ],
+            [
+                'id' => 'text',
+                'type' => 'nf-text',
+                'name' => 'Text',
+                'hidden' => false,
+            ],
+        ],
+    ]);
+
+    $prompt = new CheckSpamEmailIntegrationPrompt($form, new FormIntegration());
+    $method = new ReflectionMethod(CheckSpamEmailIntegrationPrompt::class, 'isDefaultDummyForm');
+    $method->setAccessible(true);
+
+    expect($method->invoke($prompt))->toBeTrue();
+});

--- a/api/tests/Unit/Service/Integrations/EmailIntegrationSpamServiceTest.php
+++ b/api/tests/Unit/Service/Integrations/EmailIntegrationSpamServiceTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Models\Forms\Form;
+use App\Models\Integration\FormIntegration;
+use App\Models\User;
+use App\Service\Integrations\EmailIntegrationSpamService;
+use App\Service\UserActionService;
+
+uses(\Tests\TestCase::class);
+
+it('skips ai email integration spam checks when the openai key is missing', function () {
+    config()->set('opnform.admin_emails', []);
+    config()->set('opnform.moderator_emails', []);
+    config()->set('services.openai.api_key', null);
+    config()->set('spam.enabled', true);
+    config()->set('spam.keywords', ['sign in']);
+
+    $creator = (new User())->forceFill([
+        'id' => 123,
+        'name' => 'Test User',
+        'email' => 'spam-check-ci@example.test',
+        'created_at' => now(),
+        'blocked_at' => null,
+        'meta' => [],
+    ]);
+
+    $form = (new Form())->forceFill([
+        'id' => 456,
+        'title' => 'Contact Form',
+    ]);
+    $form->setRelation('creator', $creator);
+
+    $integration = (new FormIntegration())->forceFill([
+        'id' => 789,
+        'form_id' => $form->id,
+        'integration_id' => 'email',
+        'status' => FormIntegration::STATUS_ACTIVE,
+        'data' => (object) [
+            'send_to' => $creator->email,
+            'subject' => 'Secure sign in required',
+            'email_content' => 'Please sign in to continue.',
+        ],
+    ]);
+    $integration->setRelation('form', $form);
+
+    $userActionService = Mockery::mock(UserActionService::class);
+    $userActionService->shouldNotReceive('block');
+
+    $result = (new EmailIntegrationSpamService($userActionService))->checkForSpam($form, $integration);
+
+    expect($result)->toBeNull();
+});


### PR DESCRIPTION
## Summary

- Add a shared `FormSpamContentAnalyzer` that extracts visible form content, rich text, help text, image metadata, and URLs from form properties for spam checks.
- Update form and email-integration spam prompts to use richer content context and count only active input fields.
- Expand keyword triggers for the BT-style phishing pattern, including voicemail/click-through language and Framer/Weebly landing domains.
- Add unit coverage for visible-content scanning, hidden/disabled field counting, keyword detection, and default dummy-form detection.

## Root Cause

The spam gate was looking at `fields`, but forms store their builder content in `properties`. The AI prompt also omitted high-signal content such as `nf-text`, help links, image URLs/filenames, and submitted/submit text. As a result, branded phishing landing pages with external links could look almost empty to the model.

## Validation

- `OPEN_AI_API_KEY=test ./vendor/bin/pest tests/Unit/Service/Forms/FormSpamContentAnalyzerTest.php tests/Unit/Service/Forms/FormSpamServiceTest.php tests/Unit/Service/Integrations/CheckSpamEmailIntegrationPromptTest.php`
- `./vendor/bin/pint --test app/Service/Forms/FormSpamContentAnalyzer.php app/Service/Forms/FormSpamService.php app/Service/AI/Prompts/Form/CheckSpamFormPrompt.php app/Service/AI/Prompts/Integration/CheckSpamEmailIntegrationPrompt.php config/spam.php tests/Unit/Service/Forms/FormSpamContentAnalyzerTest.php tests/Unit/Service/Forms/FormSpamServiceTest.php tests/Unit/Service/Integrations/CheckSpamEmailIntegrationPromptTest.php`

## Notes

Model changes are intentionally left out for a separate PR.