### PR TITLE
[codex] Update default AI prompt model

### DIFF
--- a/api/app/Service/AI/Prompts/Prompt.php
+++ b/api/app/Service/AI/Prompts/Prompt.php
@@ -17,7 +17,7 @@ abstract class Prompt
 
     protected ?int $maxTokens = 4096;
 
-    protected string $model = 'gpt-4.1';
+    protected string $model = 'gpt-5.4-mini';
 
     protected bool $useStreaming = false;
 

--- a/api/app/Service/OpenAi/GptCompleter.php
+++ b/api/app/Service/OpenAi/GptCompleter.php
@@ -174,7 +174,7 @@ class GptCompleter
         ];
 
         if (!is_null($maxTokens)) {
-            $completionInput['max_tokens'] = $maxTokens;
+            $completionInput[$this->maxTokensParameter()] = $maxTokens;
         }
 
         if (!is_null($temperature)) {
@@ -192,6 +192,11 @@ class GptCompleter
         $this->completionInput = $completionInput;
 
         return $this;
+    }
+
+    private function maxTokensParameter(): string
+    {
+        return str_starts_with($this->model, 'gpt-5') ? 'max_completion_tokens' : 'max_tokens';
     }
 
     protected function queryCompletion(): self

--- a/api/tests/Unit/Service/AI/Prompts/PromptModelDefaultsTest.php
+++ b/api/tests/Unit/Service/AI/Prompts/PromptModelDefaultsTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use App\Service\AI\Prompts\Prompt;
+use App\Service\OpenAi\GptCompleter;
+
+it('uses the current mini model as the base prompt model', function () {
+    $defaults = (new ReflectionClass(Prompt::class))->getDefaultProperties();
+
+    expect($defaults['model'])->toBe('gpt-5.4-mini');
+});
+
+it('does not keep legacy OpenAI model ids in active app code', function () {
+    $apiPath = dirname(__DIR__, 5);
+    $roots = [
+        $apiPath . '/app',
+        $apiPath . '/config',
+    ];
+    $legacyModels = [
+        'gpt-4.1',
+        'gpt-4o',
+        'o4-mini',
+    ];
+    $offenders = [];
+
+    foreach ($roots as $root) {
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($files as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $content = file_get_contents($file->getPathname());
+
+            foreach ($legacyModels as $legacyModel) {
+                if (str_contains($content, $legacyModel)) {
+                    $offenders[] = str_replace($apiPath . '/', '', $file->getPathname()) . " contains {$legacyModel}";
+                }
+            }
+        }
+    }
+
+    expect($offenders)->toBe([]);
+});
+
+it('builds a chat completions payload for the default model with existing parameters', function () {
+    $completer = new GptCompleter('gpt-5.4-mini', 'test-key');
+    $completer
+        ->setSystemMessage('Return a compact JSON response.')
+        ->setJsonSchema([
+            'type' => 'object',
+            'required' => ['ok'],
+            'additionalProperties' => false,
+            'properties' => [
+                'ok' => ['type' => 'boolean'],
+            ],
+        ]);
+
+    $method = new ReflectionMethod(GptCompleter::class, 'computeChatCompletion');
+    $method->setAccessible(true);
+    $method->invoke(
+        $completer,
+        [['role' => 'user', 'content' => 'Say ok.']],
+        128,
+        0.2
+    );
+
+    $property = new ReflectionProperty(GptCompleter::class, 'completionInput');
+    $property->setAccessible(true);
+    $payload = $property->getValue($completer);
+
+    expect($payload['model'])->toBe('gpt-5.4-mini')
+        ->and($payload['max_completion_tokens'])->toBe(128)
+        ->and($payload)->not->toHaveKey('max_tokens')
+        ->and($payload['temperature'])->toBe(0.2)
+        ->and($payload['messages'][0])->toBe([
+            'role' => 'system',
+            'content' => 'Return a compact JSON response.',
+        ])
+        ->and($payload['messages'][1])->toBe([
+            'role' => 'user',
+            'content' => 'Say ok.',
+        ])
+        ->and($payload['response_format']['type'])->toBe('json_schema')
+        ->and($payload['response_format']['json_schema']['strict'])->toBeTrue();
+});


### PR DESCRIPTION
## Summary

- Replace the inherited prompt default model from `gpt-4.1` to `gpt-5.4-mini`.
- Send `max_completion_tokens` instead of `max_tokens` for `gpt-5*` Chat Completions models.
- Add a guard test that fails if legacy active model IDs (`gpt-4.1`, `gpt-4o`, `o4-mini`) are reintroduced in `api/app` or `api/config`.
- Add payload coverage for the Chat Completions wrapper with `gpt-5.4-mini`, JSON schema response format, token limit, and `temperature`.

## Why

`main-v2` already uses `gpt-5.4-nano` for spam checks and `gpt-5.4-mini` for form generation, but `Prompt::$model` still defaulted to `gpt-4.1`. That meant prompts without an explicit override, currently template metadata generation, still inherited the older model.

Manual testing with a real OpenAI key also showed that `gpt-5.4-mini` rejects `max_tokens` and requires `max_completion_tokens`, so this PR updates the wrapper for `gpt-5*` models.

Docs checked:
- https://developers.openai.com/api/docs/models/gpt-5.4-mini
- https://developers.openai.com/api/reference/resources/chat

## Validation

- `OPEN_AI_API_KEY=test ./vendor/bin/pest tests/Unit/Service/AI/Prompts/PromptModelDefaultsTest.php`
- `./vendor/bin/pint --test app/Service/OpenAi/GptCompleter.php app/Service/AI/Prompts/Prompt.php tests/Unit/Service/AI/Prompts/PromptModelDefaultsTest.php`
- `rg -n "gpt-4\.1|gpt-4o|o4-mini" api/app api/config -S` returned no matches
- `php artisan tinker --execute=...` confirmed effective prompt models:
  - `Prompt`: `gpt-5.4-mini`
  - `GenerateTemplateMetadataPrompt`: `gpt-5.4-mini`
  - `GenerateFormPrompt`: `gpt-5.4-mini`
  - `GenerateFormFieldsPrompt`: `gpt-5.4-mini`
  - `CheckSpamFormPrompt`: `gpt-5.4-nano`
  - `CheckSpamEmailIntegrationPrompt`: `gpt-5.4-nano`
- Real OpenAI Tinker calls with local `.env` key:
  - `GptCompleter("gpt-5.4-mini")` simple chat returned `ok`
  - `GptCompleter("gpt-5.4-mini")` strict `json_schema` returned `{ "ok": true }`
  - anonymous `Prompt` inheriting the default model returned `{ "ok": true }`
  - `GenerateTemplateMetadataPrompt` returned valid metadata with title, industries, types, and Q&A
  - `GenerateFormPrompt` returned a valid contact form with 3 properties
  - `GenerateFormFieldsPrompt` returned one `email` field
  - `CheckSpamFormPrompt` returned a non-spam JSON verdict
  - `CheckSpamEmailIntegrationPrompt` returned a non-spam JSON verdict
  - `GptCompleter("gpt-5.4-nano")` simple chat returned `ok`

Context7 lookup was attempted but blocked by monthly quota, so I used official OpenAI docs directly.