### PR TITLE
Enhance legacy Hashid handling in PublicFormController

### DIFF
--- a/api/app/Http/Controllers/Forms/PublicFormController.php
+++ b/api/app/Http/Controllers/Forms/PublicFormController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Forms;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AnswerFormRequest;
 use App\Models\Forms\Form;
+use App\Models\Forms\FormSubmission;
 use App\Http\Resources\FormResource;
 use App\Http\Resources\FormSubmissionResource;
 use App\Jobs\Form\StoreFormSubmissionJob;
@@ -211,6 +212,28 @@ class PublicFormController extends Controller
             return $submissionData;
         }
 
+        // Only resolve identifiers when the form permits edits or partial draft updates
+        $canEditSubmissions = $form->editable_submissions
+            && $form->workspace
+            && $form->workspace->hasFeature('editable_submissions');
+        $canPartialSubmit = $form->enable_partial_submissions
+            && $form->workspace
+            && $form->workspace->hasFeature('partial_submissions');
+
+        if (!$canEditSubmissions && !$canPartialSubmit) {
+            unset($submissionData['submission_id'], $submissionData['submission_hash']);
+
+            return $submissionData;
+        }
+
+        $canUseResolvedSubmission = function (?FormSubmission $submission) use ($canEditSubmissions, $canPartialSubmit): bool {
+            if ($canEditSubmissions) {
+                return true;
+            }
+
+            return $canPartialSubmit && $submission?->status === FormSubmission::STATUS_PARTIAL;
+        };
+
         // Check if it's a UUID (new format)
         if (Str::isUuid($submissionIdentifier)) {
             $submission = $form->submissions()
@@ -218,6 +241,11 @@ class PublicFormController extends Controller
                 ->first();
             if (!$submission) {
                 abort(404, 'Submission not found');
+            }
+            if (!$canUseResolvedSubmission($submission)) {
+                unset($submissionData['submission_id'], $submissionData['submission_hash']);
+
+                return $submissionData;
             }
             $submissionData['submission_id'] = $submission->id;
             unset($submissionData['submission_hash']);
@@ -233,7 +261,9 @@ class PublicFormController extends Controller
                 if ($submission && $submission->public_id) {
                     abort(404, 'Submission not found');
                 }
-                $submissionData['submission_id'] = $numericId;
+                if ($canUseResolvedSubmission($submission)) {
+                    $submissionData['submission_id'] = $numericId;
+                }
             }
         }
         unset($submissionData['submission_hash']);

--- a/api/app/Http/Controllers/Forms/PublicFormController.php
+++ b/api/app/Http/Controllers/Forms/PublicFormController.php
@@ -227,7 +227,14 @@ class PublicFormController extends Controller
         // Legacy Hashid support (backward compatibility)
         $decodedId = Hashids::decode($submissionIdentifier);
         if (!empty($decodedId)) {
-            $submissionData['submission_id'] = (int)($decodedId[0] ?? null);
+            $numericId = (int)($decodedId[0] ?? null);
+            if ($numericId) {
+                $submission = $form->submissions()->find($numericId);
+                if ($submission && $submission->public_id) {
+                    abort(404, 'Submission not found');
+                }
+                $submissionData['submission_id'] = $numericId;
+            }
         }
         unset($submissionData['submission_hash']);
 

--- a/api/tests/Feature/Forms/SubmissionIdentifierTest.php
+++ b/api/tests/Feature/Forms/SubmissionIdentifierTest.php
@@ -133,6 +133,39 @@ describe('Legacy Hashid Backward Compatibility', function () {
         ]))->assertStatus(404);
     });
 
+    it('rejects hashid update when submission has UUID', function () {
+        $submission = new FormSubmission();
+        $submission->form_id = $this->form->id;
+        $submission->data = ['test' => 'data'];
+        $submission->public_id = Str::uuid()->toString();
+        $submission->save();
+
+        $hashid = Hashids::encode($submission->id);
+
+        $editData = $this->generateFormSubmissionData($this->form);
+        $editData['submission_id'] = $hashid;
+
+        $this->actingAsGuest();
+        $this->postJson(route('forms.answer', $this->form), $editData)
+            ->assertStatus(404);
+    });
+
+    it('allows hashid update for legacy submission without UUID', function () {
+        $submission = new FormSubmission();
+        $submission->form_id = $this->form->id;
+        $submission->data = ['test' => 'data'];
+        $submission->public_id = null;
+        $submission->save();
+
+        $hashid = Hashids::encode($submission->id);
+
+        $editData = $this->generateFormSubmissionData($this->form);
+        $editData['submission_id'] = $hashid;
+
+        $this->postJson(route('forms.answer', $this->form), $editData)
+            ->assertSuccessful();
+    });
+
     it('returns 404 for invalid hashid', function () {
         $this->actingAsGuest();
         $this->getJson(route('forms.fetchSubmission', [

--- a/api/tests/Feature/Forms/SubmissionIdentifierTest.php
+++ b/api/tests/Feature/Forms/SubmissionIdentifierTest.php
@@ -218,6 +218,93 @@ describe('Submission Fetch Authorization', function () {
     });
 });
 
+describe('Submission update blocked when editable submissions disabled', function () {
+    it('does not update legacy submission via hashid when editable_submissions is false', function () {
+        $user = $this->actingAsBusinessUser();
+        $workspace = $this->createUserWorkspace($user);
+        $form = $this->createForm($user, $workspace, [
+            'editable_submissions' => false,
+        ]);
+
+        $submission = new FormSubmission();
+        $submission->form_id = $form->id;
+        $submission->data = ['original' => 'data'];
+        $submission->public_id = null;
+        $submission->save();
+
+        $originalData = $submission->data;
+        $hashid = Hashids::encode($submission->id);
+
+        $editData = $this->generateFormSubmissionData($form);
+        $editData['submission_id'] = $hashid;
+
+        $this->postJson(route('forms.answer', $form), $editData)
+            ->assertSuccessful();
+
+        // Should have created a new submission, not updated the existing one
+        expect($form->submissions()->count())->toBe(2);
+        $submission->refresh();
+        expect($submission->data)->toBe($originalData);
+    });
+
+    it('does not update submission via UUID when editable_submissions is false', function () {
+        $user = $this->actingAsBusinessUser();
+        $workspace = $this->createUserWorkspace($user);
+        $form = $this->createForm($user, $workspace, [
+            'editable_submissions' => false,
+        ]);
+
+        $submission = new FormSubmission();
+        $submission->form_id = $form->id;
+        $submission->data = ['original' => 'data'];
+        $submission->public_id = Str::uuid()->toString();
+        $submission->save();
+
+        $originalData = $submission->data;
+
+        $editData = $this->generateFormSubmissionData($form);
+        $editData['submission_id'] = $submission->public_id;
+
+        $this->postJson(route('forms.answer', $form), $editData)
+            ->assertSuccessful();
+
+        // Should have created a new submission, not updated the existing one
+        expect($form->submissions()->count())->toBe(2);
+        $submission->refresh();
+        expect($submission->data)->toBe($originalData);
+    });
+
+    it('does not update completed legacy submission when only partial submissions are enabled', function () {
+        $user = $this->actingAsBusinessUser();
+        $workspace = $this->createUserWorkspace($user);
+        $form = $this->createForm($user, $workspace, [
+            'editable_submissions' => false,
+            'enable_partial_submissions' => true,
+        ]);
+
+        $submission = new FormSubmission();
+        $submission->form_id = $form->id;
+        $submission->data = ['original' => 'data'];
+        $submission->status = FormSubmission::STATUS_COMPLETED;
+        $submission->public_id = null;
+        $submission->save();
+
+        $originalData = $submission->data;
+        $hashid = Hashids::encode($submission->id);
+
+        $editData = $this->generateFormSubmissionData($form);
+        $editData['submission_id'] = $hashid;
+
+        $this->postJson(route('forms.answer', $form), $editData)
+            ->assertSuccessful();
+
+        expect($form->submissions()->count())->toBe(2);
+        $submission->refresh();
+        expect($submission->status)->toBe(FormSubmission::STATUS_COMPLETED);
+        expect($submission->data)->toBe($originalData);
+    });
+});
+
 describe('Partial Submissions with UUID', function () {
     it('generates UUID for partial submissions', function () {
         $user = $this->actingAsBusinessUser();


### PR DESCRIPTION
- Refactor submission ID decoding logic to check for existing submissions with UUIDs and return a 404 error if found.
- Add tests to ensure proper handling of Hashid updates based on submission UUID presence, allowing updates for legacy submissions without UUIDs while rejecting those with UUIDs.