### PR TITLE
[codex] Provision self-hosted Stripe pricing

### DIFF
--- a/api/app/Service/Billing/StripePricingProvisioner.php
+++ b/api/app/Service/Billing/StripePricingProvisioner.php
@@ -41,6 +41,7 @@ class StripePricingProvisioner
             $this->makePlanDefinition($mode, 'pro', 'pro', 'OpnForm Pro'),
             $this->makePlanDefinition($mode, 'business', 'business', 'OpnForm Business'),
             $this->makePlanDefinition($mode, 'enterprise', 'enterprise', 'OpnForm Enterprise'),
+            $this->makePlanDefinition($mode, 'self_hosted', 'self_hosted', 'OpnForm Self-hosted Enterprise'),
         ];
 
         if ($includeLegacyDefault) {

--- a/api/tests/Feature/Console/ProvisionStripePricingCommandTest.php
+++ b/api/tests/Feature/Console/ProvisionStripePricingCommandTest.php
@@ -43,6 +43,30 @@ it('supports dry run without writing env values', function () {
                     ],
                 ],
             ],
+            [
+                'plan' => 'self_hosted',
+                'tier' => 'self_hosted',
+                'product' => [
+                    'id' => null,
+                    'env_key' => 'STRIPE_TEST_SELF_HOSTED_PRODUCT_ID',
+                    'action' => 'would_create',
+                    'display_name' => 'OpnForm Self-hosted Enterprise',
+                ],
+                'prices' => [
+                    'monthly' => [
+                        'id' => null,
+                        'env_key' => 'STRIPE_TEST_SELF_HOSTED_PRICING_MONTHLY',
+                        'action' => 'would_create',
+                        'amount' => 19900,
+                    ],
+                    'yearly' => [
+                        'id' => null,
+                        'env_key' => 'STRIPE_TEST_SELF_HOSTED_PRICING_YEARLY',
+                        'action' => 'would_create',
+                        'amount' => 199900,
+                    ],
+                ],
+            ],
         ]);
     $provisioner->shouldNotReceive('writeEnvValues');
 
@@ -54,6 +78,10 @@ it('supports dry run without writing env values', function () {
         ->expectsOutput('  product [would_create] STRIPE_TEST_PRO_PRODUCT_ID=(would create)')
         ->expectsOutput('  monthly [would_create] STRIPE_TEST_PRO_PRICING_MONTHLY=(would create) $29')
         ->expectsOutput('  yearly  [would_create] STRIPE_TEST_PRO_PRICING_YEARLY=(would create) $299')
+        ->expectsOutput('SELF_HOSTED (OpnForm Self-hosted Enterprise)')
+        ->expectsOutput('  product [would_create] STRIPE_TEST_SELF_HOSTED_PRODUCT_ID=(would create)')
+        ->expectsOutput('  monthly [would_create] STRIPE_TEST_SELF_HOSTED_PRICING_MONTHLY=(would create) $199')
+        ->expectsOutput('  yearly  [would_create] STRIPE_TEST_SELF_HOSTED_PRICING_YEARLY=(would create) $1,999')
         ->expectsOutput('Dry run mode: no Stripe resources were created and .env was not modified.')
         ->assertExitCode(0);
 });

--- a/api/tests/Unit/Service/StripePricingProvisionerTest.php
+++ b/api/tests/Unit/Service/StripePricingProvisionerTest.php
@@ -18,9 +18,19 @@ it('infers provisioning mode from stripe secret prefix', function () {
 it('builds current plan definitions without legacy default by default', function () {
     $definitions = $this->provisioner->getPlanDefinitions(StripePricingProvisioner::MODE_TEST);
 
-    expect(array_column($definitions, 'plan'))->toBe(['pro', 'business', 'enterprise']);
+    expect(array_column($definitions, 'plan'))->toBe(['pro', 'business', 'enterprise', 'self_hosted']);
     expect($definitions[0]['env']['product_id'])->toBe('STRIPE_TEST_PRO_PRODUCT_ID');
     expect($definitions[2]['env']['yearly'])->toBe('STRIPE_TEST_ENTERPRISE_PRICING_YEARLY');
+    expect($definitions[3]['product_name'])->toBe('OpnForm Self-hosted Enterprise');
+    expect($definitions[3]['amounts'])->toBe([
+        'monthly' => 19900,
+        'yearly' => 199900,
+    ]);
+    expect($definitions[3]['env'])->toBe([
+        'product_id' => 'STRIPE_TEST_SELF_HOSTED_PRODUCT_ID',
+        'monthly' => 'STRIPE_TEST_SELF_HOSTED_PRICING_MONTHLY',
+        'yearly' => 'STRIPE_TEST_SELF_HOSTED_PRICING_YEARLY',
+    ]);
 });
 
 it('writes env values only for missing or empty keys', function () {


### PR DESCRIPTION
## Summary
- include self-hosted Enterprise in the Stripe pricing provisioner by default
- cover self-hosted env keys and /month / ,999/year amounts in provisioning tests
- ensure dry-run output includes the self-hosted product and prices

## Validation
- ./vendor/bin/pest tests/Unit/Service/StripePricingProvisionerTest.php tests/Feature/Console/ProvisionStripePricingCommandTest.php
- ./vendor/bin/pint --test app/Service/Billing/StripePricingProvisioner.php tests/Unit/Service/StripePricingProvisionerTest.php tests/Feature/Console/ProvisionStripePricingCommandTest.php
- git diff --check