### PR TITLE
Feat: custom form field IDs

### DIFF
--- a/api/app/Rules/FormPropertiesRule.php
+++ b/api/app/Rules/FormPropertiesRule.php
@@ -96,6 +96,22 @@ class FormPropertiesRule implements ValidationRule, ValidatorAwareRule
             }
         }
 
+        // Enforce unique IDs across all properties
+        $ids = array_filter(array_column($value, 'id'), fn($id) => $id !== null && $id !== '');
+        $duplicateIds = array_filter(array_count_values($ids), fn($count) => $count > 1);
+
+        if (!empty($duplicateIds)) {
+            foreach ($value as $index => $property) {
+                if (isset($property['id']) && $property['id'] !== '' && isset($duplicateIds[$property['id']])) {
+                    $errorKey = "properties.{$index}.id";
+                    if (!isset($allErrors[$errorKey])) {
+                        $allErrors[$errorKey] = [];
+                    }
+                    $allErrors[$errorKey][] = "The id for form block number " . ($index + 1) . " must be unique.";
+                }
+            }
+        }
+
         // Add errors directly to the validator's message bag
         // This ensures proper error format matching Laravel's wildcard validation
         if ($this->validator && !empty($allErrors)) {

--- a/api/app/Rules/PropertyValidators/CorePropertyValidator.php
+++ b/api/app/Rules/PropertyValidators/CorePropertyValidator.php
@@ -23,6 +23,8 @@ class CorePropertyValidator implements PropertyValidatorInterface
         // Required fields
         if (!isset($property['id']) || $property['id'] === '' || $property['id'] === null) {
             $errors['id'] = "The form block number {$position} is missing an id.";
+        } elseif (!preg_match('/^[a-zA-Z0-9_\-]+$/', strval($property['id']))) {
+            $errors['id'] = "The form block number {$position} has an invalid id. IDs may only contain letters, numbers, hyphens, and underscores.";
         }
 
         if (!isset($property['name']) || $property['name'] === '' || $property['name'] === null) {

--- a/api/tests/Unit/Rules/FormPropertiesRuleTest.php
+++ b/api/tests/Unit/Rules/FormPropertiesRuleTest.php
@@ -181,6 +181,52 @@ describe('FormPropertiesRule', function () {
             expect($validator->errors()->has('properties.0.width'))->toBeTrue();
         });
 
+        it('fails when id contains invalid characters', function () {
+            $rules = [
+                'properties' => ['required', 'array', new FormPropertiesRule()],
+            ];
+
+            $data = [
+                'properties' => [
+                    [
+                        'id' => 'title with spaces',
+                        'name' => 'Title',
+                        'type' => 'text',
+                    ],
+                ],
+            ];
+
+            $validator = $this->app['validator']->make($data, $rules);
+            expect($validator->passes())->toBeFalse();
+            expect($validator->errors()->has('properties.0.id'))->toBeTrue();
+        });
+
+        it('fails when property ids are duplicated', function () {
+            $rules = [
+                'properties' => ['required', 'array', new FormPropertiesRule()],
+            ];
+
+            $data = [
+                'properties' => [
+                    [
+                        'id' => 'duplicate',
+                        'name' => 'Title',
+                        'type' => 'text',
+                    ],
+                    [
+                        'id' => 'duplicate',
+                        'name' => 'Email',
+                        'type' => 'email',
+                    ],
+                ],
+            ];
+
+            $validator = $this->app['validator']->make($data, $rules);
+            expect($validator->passes())->toBeFalse();
+            expect($validator->errors()->has('properties.0.id'))->toBeTrue();
+            expect($validator->errors()->has('properties.1.id'))->toBeTrue();
+        });
+
         it('passes with valid width value', function () {
             $rules = [
                 'properties' => ['required', 'array', new FormPropertiesRule()],

--- a/client/components/open/forms/fields/components/FieldOptions.vue
+++ b/client/components/open/forms/fields/components/FieldOptions.vue
@@ -13,6 +13,23 @@
         wrapper-class="mb-2"
         label="Field Name"
       />
+      <text-input
+        name="id"
+        class="mt-2"
+        :form="field"
+        :required="true"
+        wrapper-class="mb-2"
+        label="Field ID"
+        placeholder="Use letters, numbers, hyphens, or underscores"
+        pattern="^[a-zA-Z0-9_\-]+$"
+        help="Unique identifier used for submissions, logic, mentions, and redirects. Must be unique and may only contain letters, numbers, hyphens, and underscores."
+      >
+        <template #error v-if="fieldIdErrors.length">
+          <div class="text-sm text-red-500">
+            <div v-for="(error, index) in fieldIdErrors" :key="index">{{ error }}</div>
+          </div>
+        </template>
+      </text-input>
       <HiddenRequiredDisabled
         class="mt-4"
         :field="field"
@@ -722,6 +739,28 @@ export default {
     },
     shouldEnableSelectSearch() {
       return ['select', 'multi_select'].includes(this.field.type) && this.selectionOptionsCount > 5
+    },
+    fieldIdErrors() {
+      const errors = []
+      const id = this.field?.id?.toString()?.trim() ?? ''
+      const pattern = /^[a-zA-Z0-9_\-]+$/
+
+      if (!id) {
+        errors.push('Field ID is required.')
+      } else {
+        if (!pattern.test(id)) {
+          errors.push('Field ID may only contain letters, numbers, hyphens, and underscores.')
+        }
+
+        if (this.form?.properties) {
+          const duplicateCount = this.form.properties.filter((property) => property?.id === id).length
+          if (duplicateCount > 1) {
+            errors.push('Field ID must be unique among all form fields.')
+          }
+        }
+      }
+
+      return errors
     },
     timezonesOptions() {
       if (this.field.type !== 'date') return []


### PR DESCRIPTION
Based off of feedback comment #1049 

- Added input field to form field settings that shows the form ID that is currently automatically created
- Allows editing the field ID
- Checks for uniqueness and gives validation errors on public if conditions are not met

**DISCLOSURE**: Claude was used to create this 

<img width="1056" height="350" alt="image" src="https://github.com/user-attachments/assets/cdf16207-9f11-43e6-bf3a-bd8193a78919" />
<img width="1054" height="403" alt="image" src="https://github.com/user-attachments/assets/694c7afd-030a-42a9-9b5e-52d7273915f7" />
<img width="1053" height="507" alt="image" src="https://github.com/user-attachments/assets/0c49beae-80fd-4b29-8f7b-3b610202c221" />

