### PR TITLE
ESC-883 = Enhance API rate limiting for export endpoints

### DIFF
--- a/api/app/Providers/RouteServiceProvider.php
+++ b/api/app/Providers/RouteServiceProvider.php
@@ -56,6 +56,16 @@ class RouteServiceProvider extends ServiceProvider
             return Limit::perMinute(30)->by($request->user()?->id ?: $request->ip());
         });
 
+        // Export endpoints use dedicated buckets so long-running CSV exports
+        // are not blocked by the general API rate limit.
+        RateLimiter::for('export', function (Request $request) {
+            return Limit::perMinute(10)->by($request->user()?->id ?: $request->ip());
+        });
+
+        RateLimiter::for('export-status', function (Request $request) {
+            return Limit::perMinute(180)->by($request->user()?->id ?: $request->ip());
+        });
+
         RateLimiter::for('public-uploads', function (Request $request) {
             $identifier = $request->user()
                 ? 'user:' . $request->user()->getAuthIdentifier()

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -212,8 +212,14 @@ Route::group(['middleware' => 'auth.multi'], function () {
                 Route::get('/', [FormSubmissionController::class, 'submissions'])->name('index');
                 Route::get('/{submission_id}', [FormSubmissionController::class, 'fetch'])->name('fetch');
                 Route::put('/{submission_id}', [FormSubmissionController::class, 'update'])->name('update');
-                Route::post('/export', [FormSubmissionController::class, 'export'])->name('export');
-                Route::get('/export/status/{jobId}', [FormSubmissionController::class, 'exportStatus'])->name('export.status');
+                Route::post('/export', [FormSubmissionController::class, 'export'])
+                    ->withoutMiddleware(['throttle:100,1'])
+                    ->middleware('throttle:export')
+                    ->name('export');
+                Route::get('/export/status/{jobId}', [FormSubmissionController::class, 'exportStatus'])
+                    ->withoutMiddleware(['throttle:100,1'])
+                    ->middleware('throttle:export-status')
+                    ->name('export.status');
                 Route::get('/file/{filename}', [FormSubmissionController::class, 'submissionFile'])
                     ->middleware('signed')
                     ->withoutMiddleware(['auth.multi'])

--- a/api/tests/Feature/Forms/FormSubmissionExportTest.php
+++ b/api/tests/Feature/Forms/FormSubmissionExportTest.php
@@ -4,7 +4,10 @@ use App\Models\User;
 use App\Models\Forms\FormSubmission;
 use App\Service\Forms\FormSubmissionFormatter;
 use App\Service\Storage\FileUploadPathService;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 
 function parseCsvRows(string $content): array
 {
@@ -404,4 +407,42 @@ it('exports file urls with a durable expiration and a valid signature', function
     $this->get($exportedFileUrl)->assertOk();
 
     $this->travelBack();
+});
+
+it('allows export status polling when the general api rate limit is exhausted', function () {
+    $this->withMiddleware(ThrottleRequests::class);
+
+    $router = app('router');
+    $apiMiddleware = $router->getMiddlewareGroups()['api'];
+    array_unshift($apiMiddleware, 'throttle:100,1');
+    $router->middlewareGroup('api', $apiMiddleware);
+
+    $user = $this->actingAsProUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace);
+
+    $jobId = (string) Str::uuid();
+    Cache::put('form_export_job:' . $jobId, [
+        'status' => 'processing',
+        'progress' => 50,
+        'form_id' => $form->id,
+        'user_id' => $user->id,
+        'created_at' => now()->toISOString(),
+        'updated_at' => now()->toISOString(),
+    ], now()->addHour());
+
+    for ($i = 0; $i < 100; $i++) {
+        $this->getJson(route('open.forms.submissions.index', ['form' => $form]))
+            ->assertSuccessful();
+    }
+
+    $this->getJson(route('open.forms.submissions.index', ['form' => $form]))
+        ->assertStatus(429);
+
+    $this->getJson(route('open.forms.submissions.export.status', [
+        'form' => $form,
+        'jobId' => $jobId,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonPath('status', 'processing');
 });

--- a/client/components/open/forms/FormExportModal.vue
+++ b/client/components/open/forms/FormExportModal.vue
@@ -73,7 +73,7 @@
               <div class="space-y-3">
                 <p class="text-red-600 font-semibold text-lg">Export failed</p>
                 <p class="text-sm text-neutral-600">{{ exportError }}</p>
-                <UButton color="red" @click="closeModal">Close</UButton>
+                <UButton color="neutral" @click="closeModal" label="Close" />
               </div>
             </div>
 


### PR DESCRIPTION
- Introduced dedicated rate limits for CSV export and export status endpoints to prevent long-running exports from being blocked by general API limits.
- Updated route definitions to apply the new throttling middleware for export operations, ensuring smoother user experience during data exports.
- Added tests to verify the functionality of the new rate limits and ensure compliance with expected behavior.

These changes improve the performance and reliability of the export features in the application.