### PR TITLE
BE-002 - Enhance form summary controller and testing for workspace validation

### DIFF
--- a/api/app/Http/Controllers/Forms/FormSummaryController.php
+++ b/api/app/Http/Controllers/Forms/FormSummaryController.php
@@ -19,6 +19,7 @@ class FormSummaryController extends Controller
 
     public function getSummary(FormSummaryRequest $request, Workspace $workspace, Form $form): JsonResponse
     {
+        $this->ensureFormBelongsToWorkspace($form, $workspace);
         $this->authorize('view', $form);
 
         $summary = $this->summaryService->generateSummary(
@@ -33,6 +34,7 @@ class FormSummaryController extends Controller
 
     public function getFieldValues(FormSummaryRequest $request, Workspace $workspace, Form $form, string $fieldId): JsonResponse
     {
+        $this->ensureFormBelongsToWorkspace($form, $workspace);
         $this->authorize('view', $form);
 
         $values = $this->summaryService->getFieldTextValues(
@@ -49,5 +51,12 @@ class FormSummaryController extends Controller
         }
 
         return response()->json($values);
+    }
+
+    private function ensureFormBelongsToWorkspace(Form $form, Workspace $workspace): void
+    {
+        if ($form->workspace_id !== $workspace->id) {
+            abort(404);
+        }
     }
 }

--- a/api/tests/Feature/Forms/FormSummaryTest.php
+++ b/api/tests/Feature/Forms/FormSummaryTest.php
@@ -280,6 +280,22 @@ describe('Form Summary', function () {
         $this->getJson(route('open.workspaces.form.summary', [$otherWorkspace, $otherForm]))
             ->assertStatus(402);
     });
+
+    it('returns 404 when workspace and form do not match on summary endpoints', function () {
+        $workspaceA = $this->createUserWorkspace($this->user);
+        $workspaceB = $this->createUserWorkspace($this->user);
+        $formInWorkspaceA = $this->createForm($this->user, $workspaceA);
+        $nameProperty = collect($formInWorkspaceA->properties)->firstWhere('name', 'Name');
+
+        $this->getJson(route('open.workspaces.form.summary', [$workspaceB, $formInWorkspaceA]))
+            ->assertStatus(404);
+
+        $this->getJson(route('open.workspaces.form.summary.field-values', [
+            $workspaceB,
+            $formInWorkspaceA,
+            $nameProperty['id'],
+        ]))->assertStatus(404);
+    });
 });
 
 describe('Form Summary Field Values (Load More)', function () {


### PR DESCRIPTION
- Added a method in `FormSummaryController` to ensure forms belong to the correct workspace, improving data integrity and access control.
- Updated tests in `FormSummaryTest` to verify that summary endpoints return a 404 status when the form and workspace do not match, enhancing error handling and user feedback.

These changes strengthen the validation logic for form summaries, ensuring users can only access summaries for forms within their respective workspaces.