### PR TITLE
BE-010-Enhance XML export command and add unit tests for file writing functi…

### DIFF
--- a/api/app/Console/Commands/Tax/GenerateDesXmlExport.php
+++ b/api/app/Console/Commands/Tax/GenerateDesXmlExport.php
@@ -6,6 +6,7 @@ use App\Services\Tax\StripeExportDatasetService;
 use App\Services\Tax\StripeExportDatasetStore;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
 use Laravel\Cashier\Cashier;
 use Stripe\Invoice;
 
@@ -124,14 +125,49 @@ class GenerateDesXmlExport extends Command
         // Generate XML
         $xml = $this->generateXml($invoices);
 
-        // Save XML file with .xml extension
+        $xmlString = $xml->asXML();
+        if ($xmlString === false) {
+            $this->error('Failed to serialize XML.');
+            return Command::FAILURE;
+        }
+
         $period = Carbon::parse($startDate)->format('Ym');
         $filename = "DES_{$period}.xml";
-        file_put_contents(storage_path("app/{$filename}"), $xml->asXML());
+        $targetPath = storage_path("app/{$filename}");
 
-        $this->info("XML file generated: " . storage_path("app/{$filename}"));
+        try {
+            $writtenPath = $this->writeXmlFile($filename, $xmlString);
+        } catch (\Throwable $e) {
+            $this->error("Failed to write XML file: {$targetPath}");
+            $this->error($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        $this->info("XML file generated: {$writtenPath}");
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * Write XML atomically via a temporary file, then rename into place.
+     *
+     * @throws \RuntimeException
+     */
+    private function writeXmlFile(string $filename, string $contents): string
+    {
+        $disk = Storage::disk('local');
+        $tempFilename = $filename . '.' . uniqid('tmp', true);
+
+        if ($disk->put($tempFilename, $contents) === false) {
+            throw new \RuntimeException('Failed to write temporary XML file.');
+        }
+
+        if (!$disk->move($tempFilename, $filename)) {
+            $disk->delete($tempFilename);
+            throw new \RuntimeException("Failed to write XML file: {$disk->path($filename)}");
+        }
+
+        return $disk->path($filename);
     }
 
     private function getInvoices($startDate, $endDate)

--- a/api/tests/Unit/Console/Commands/Tax/GenerateDesXmlExportTest.php
+++ b/api/tests/Unit/Console/Commands/Tax/GenerateDesXmlExportTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\Console\Commands\Tax\GenerateDesXmlExport;
+use Illuminate\Support\Facades\Storage;
+
+uses(\Tests\TestCase::class);
+
+it('writes des xml through storage with atomic rename', function () {
+    Storage::fake('local');
+
+    $command = app(GenerateDesXmlExport::class);
+    $method = new ReflectionMethod(GenerateDesXmlExport::class, 'writeXmlFile');
+    $method->setAccessible(true);
+
+    $path = $method->invoke($command, 'DES_202401.xml', '<?xml version="1.0"?><fichier_des/>');
+
+    expect(Storage::disk('local')->exists('DES_202401.xml'))->toBeTrue();
+    expect($path)->toEndWith('DES_202401.xml');
+    expect(Storage::disk('local')->get('DES_202401.xml'))->toBe('<?xml version="1.0"?><fichier_des/>');
+});


### PR DESCRIPTION
…onality

- Updated the `GenerateDesXmlExport` command to improve XML serialization and implement atomic file writing using a temporary file approach.
- Introduced error handling for file writing failures, providing clearer feedback on issues encountered during the export process.
- Added a new test suite for `GenerateDesXmlExport` to validate the atomic file writing functionality, ensuring that XML files are correctly generated and stored.
- Enhanced overall reliability and maintainability of the XML export feature, improving user experience during tax data exports.