### PR TITLE
BE-014 - Enhance image cover URL retrieval and add unit tests for template gen…

### DIFF
--- a/api/app/Jobs/Template/GenerateTemplateJob.php
+++ b/api/app/Jobs/Template/GenerateTemplateJob.php
@@ -77,14 +77,36 @@ class GenerateTemplateJob implements ShouldQueue
      */
     private function getImageCoverUrl($searchQuery): ?string
     {
-        $url = 'https://api.unsplash.com/search/photos?query=' . urlencode($searchQuery) . '&client_id=' . config('services.unsplash.access_key');
-        $response = Http::get($url)->json();
-        $photoIndex = rand(0, max(count($response['results']) - 1, 10));
-        if (isset($response['results'][$photoIndex]['urls']['regular'])) {
-            return Str::of($response['results'][$photoIndex]['urls']['regular'])->replace('w=1080', 'w=600')->toString();
+        $searchQuery = trim((string) $searchQuery);
+        if ($searchQuery === '') {
+            return null;
         }
 
-        return null;
+        $accessKey = config('services.unsplash.access_key');
+        if (!$accessKey) {
+            return null;
+        }
+
+        $url = 'https://api.unsplash.com/search/photos?query=' . urlencode($searchQuery) . '&client_id=' . $accessKey;
+        $response = Http::get($url)->json();
+
+        if (!is_array($response)) {
+            return null;
+        }
+
+        $results = $response['results'] ?? null;
+        if (!is_array($results) || count($results) === 0) {
+            return null;
+        }
+
+        $photoIndex = random_int(0, count($results) - 1);
+        $photoUrl = $results[$photoIndex]['urls']['regular'] ?? null;
+
+        if (!$photoUrl) {
+            return null;
+        }
+
+        return Str::of($photoUrl)->replace('w=1080', 'w=600')->toString();
     }
 
     private function getRelatedTemplates(array $industries, array $types): array

--- a/api/tests/Unit/Jobs/Template/GenerateTemplateJobTest.php
+++ b/api/tests/Unit/Jobs/Template/GenerateTemplateJobTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use App\Jobs\Template\GenerateTemplateJob;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+
+uses(\Tests\TestCase::class);
+
+beforeEach(function () {
+    Config::set('services.unsplash.access_key', 'test-unsplash-key');
+});
+
+it('returns null when unsplash response has no results', function () {
+    Http::fake([
+        'api.unsplash.com/*' => Http::response(['results' => []]),
+    ]);
+
+    $job = new GenerateTemplateJob('prompt');
+    $method = new ReflectionMethod(GenerateTemplateJob::class, 'getImageCoverUrl');
+    $method->setAccessible(true);
+
+    expect($method->invoke($job, 'office workspace'))->toBeNull();
+});
+
+it('returns null when unsplash response is not an array', function () {
+    Http::fake([
+        'api.unsplash.com/*' => Http::response('not-json', 500),
+    ]);
+
+    $job = new GenerateTemplateJob('prompt');
+    $method = new ReflectionMethod(GenerateTemplateJob::class, 'getImageCoverUrl');
+    $method->setAccessible(true);
+
+    expect($method->invoke($job, 'office workspace'))->toBeNull();
+});
+
+it('returns a resized image url from unsplash results', function () {
+    Http::fake([
+        'api.unsplash.com/*' => Http::response([
+            'results' => [
+                ['urls' => ['regular' => 'https://images.unsplash.com/photo-1?w=1080&h=720']],
+                ['urls' => ['regular' => 'https://images.unsplash.com/photo-2?w=1080&h=720']],
+            ],
+        ]),
+    ]);
+
+    $job = new GenerateTemplateJob('prompt');
+    $method = new ReflectionMethod(GenerateTemplateJob::class, 'getImageCoverUrl');
+    $method->setAccessible(true);
+
+    $url = $method->invoke($job, 'office workspace');
+
+    expect($url)->toBeString();
+    expect($url)->toContain('w=600');
+    expect($url)->not->toContain('w=1080');
+});


### PR DESCRIPTION
…eration job

- Improved the `getImageCoverUrl` method in `GenerateTemplateJob` to handle empty search queries and missing Unsplash access keys gracefully, ensuring robust error handling.
- Updated the logic to validate the API response structure, ensuring that only valid results are processed.
- Introduced a new test suite for `GenerateTemplateJob` to validate the behavior of the `getImageCoverUrl` method under various scenarios, including empty results and invalid responses.
- Added tests to confirm the correct resizing of image URLs and the handling of edge cases, enhancing overall test coverage for the template generation functionality.