### PR TITLE
BE-017 - Refactor migration to correct access token removal from user_workspac…

### DIFF
--- a/api/database/migrations/2022_09_12_074636_remove_access_token_from_workspaces.php
+++ b/api/database/migrations/2022_09_12_074636_remove_access_token_from_workspaces.php
@@ -26,7 +26,7 @@ return new class () extends Migration {
      */
     public function down()
     {
-        Schema::table('workspaces', function (Blueprint $table) {
+        Schema::table('user_workspace', function (Blueprint $table) {
             $table->string('access_token')->nullable();
             $table->boolean('is_owner')->default(true);
             $table->dropColumn('role');


### PR DESCRIPTION
…e table

- Updated the migration file to change the target table from 'workspaces' to 'user_workspace' for the removal of the access token column.
- Ensured that the migration correctly reflects the intended schema changes for user workspaces, enhancing data integrity and consistency.

These changes improve the accuracy of the database migration process related to user workspaces.