### PR TITLE
[codex] Backfill legacy select option ids

### DIFF
--- a/api/app/Http/Requests/UserFormRequest.php
+++ b/api/app/Http/Requests/UserFormRequest.php
@@ -36,6 +36,10 @@ abstract class UserFormRequest extends \Illuminate\Foundation\Http\FormRequest
 
         if (isset($data['properties']) && is_array($data['properties'])) {
             $data['properties'] = array_map(function ($property) {
+                if (!is_array($property)) {
+                    return $property;
+                }
+
                 if (isset($property['name']) && is_string($property['name'])) {
                     $property['name'] = trim(strip_tags($property['name']));
                 }
@@ -46,11 +50,42 @@ abstract class UserFormRequest extends \Illuminate\Foundation\Http\FormRequest
                         $property['help'] = null;
                     }
                 }
+                $property = $this->normalizeSelectOptionIds($property);
                 return $property;
             }, $data['properties']);
         }
 
         $this->merge($data);
+    }
+
+    /**
+     * Backfill option ids for legacy select fields before strict property validation runs.
+     */
+    private function normalizeSelectOptionIds(array $property): array
+    {
+        $type = $property['type'] ?? null;
+
+        if (!in_array($type, ['select', 'multi_select'], true)) {
+            return $property;
+        }
+
+        if (!isset($property[$type]['options']) || !is_array($property[$type]['options'])) {
+            return $property;
+        }
+
+        $property[$type]['options'] = array_map(function ($option) {
+            if (!is_array($option) || !empty($option['id'] ?? null)) {
+                return $option;
+            }
+
+            if (!empty($option['name'] ?? null) && is_string($option['name'])) {
+                $option['id'] = $option['name'];
+            }
+
+            return $option;
+        }, $property[$type]['options']);
+
+        return $property;
     }
 
     /**

--- a/api/tests/Feature/Forms/FormTest.php
+++ b/api/tests/Feature/Forms/FormTest.php
@@ -130,6 +130,78 @@ it('can update a form', function () {
     ]);
 });
 
+it('backfills missing select option ids when creating a form', function () {
+    $user = $this->actingAsUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->makeForm($user, $workspace);
+
+    $form->properties = array_merge($form->properties, [
+        [
+            'id' => 'legacy_select',
+            'name' => 'Legacy Select',
+            'type' => 'select',
+            'required' => false,
+            'select' => [
+                'options' => [
+                    ['name' => 'First legacy option'],
+                    ['name' => 'Second legacy option', 'id' => 'existing-option-id'],
+                ],
+            ],
+        ],
+    ]);
+
+    $formData = (new \App\Http\Resources\FormResource($form))->toArray(request());
+
+    $response = $this->postJson(route('open.forms.store', $formData))
+        ->assertSuccessful()
+        ->assertJson([
+            'type' => 'success',
+            'message' => 'Form created.',
+        ]);
+
+    $createdForm = \App\Models\Forms\Form::find($response->json('form.id'));
+    $legacySelect = collect($createdForm->properties)->firstWhere('id', 'legacy_select');
+
+    expect($legacySelect['select']['options'][0]['id'])->toBe('First legacy option');
+    expect($legacySelect['select']['options'][1]['id'])->toBe('existing-option-id');
+});
+
+it('backfills missing multi select option ids when updating a form', function () {
+    $user = $this->actingAsUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace);
+
+    $form->properties = array_merge($form->properties, [
+        [
+            'id' => 'legacy_multi_select',
+            'name' => 'Legacy Multi Select',
+            'type' => 'multi_select',
+            'required' => false,
+            'multi_select' => [
+                'options' => [
+                    ['name' => 'Legacy choice'],
+                    ['name' => 'Existing choice', 'id' => 'existing-choice-id'],
+                ],
+            ],
+        ],
+    ]);
+
+    $formData = (new \App\Http\Resources\FormResource($form))->toArray(request());
+
+    $this->putJson(route('open.forms.update', $form->id), $formData)
+        ->assertSuccessful()
+        ->assertJson([
+            'type' => 'success',
+            'message' => 'Form updated.',
+        ]);
+
+    $form->refresh();
+    $legacyMultiSelect = collect($form->properties)->firstWhere('id', 'legacy_multi_select');
+
+    expect($legacyMultiSelect['multi_select']['options'][0]['id'])->toBe('Legacy choice');
+    expect($legacyMultiSelect['multi_select']['options'][1]['id'])->toBe('existing-choice-id');
+});
+
 it('can regenerate a form url', function () {
     $user = $this->actingAsUser();
     $workspace = $this->createUserWorkspace($user);


### PR DESCRIPTION
## Summary

Backfills missing option ids for legacy `select` and `multi_select` fields during form create/update request preparation.

## Root Cause

`OpnForm V2 (#1053)` added strict backend validation requiring every select option to include an `id`. Some existing/legacy form payloads can still contain options shaped like `{ "name": "Option" }`, which causes form saves to fail with `The option id is required.` and the aggregate `One or more properties have validation errors.` message.

## Changes

- Normalize select and multi-select options in `UserFormRequest::prepareForValidation()` before `FormPropertiesRule` runs.
- Preserve existing option ids.
- Use the option name as the backfilled id for legacy options, matching the old label-as-value shape where possible.
- Leave invalid/empty options for the existing validator to reject.
- Add feature coverage for legacy option payloads on form creation and update.

## Validation

- `./vendor/bin/pest tests/Feature/Forms/FormTest.php`
- `./vendor/bin/pest tests/Unit/Rules/SelectOptionsPropertyValidatorTest.php tests/Unit/Rules/FormPropertiesRuleTest.php --filter='select|option|properties'`
- `./vendor/bin/pint app/Http/Requests/UserFormRequest.php tests/Feature/Forms/FormTest.php`

Note: `php artisan test --filter='backfills missing'` is not available in this local environment because the Artisan `test` command is not registered, so validation used the local Pest binary directly.