### PR TITLE
[codex] Fix AppSumo feature plan tags

### DIFF
--- a/client/components/app/PlanTag.vue
+++ b/client/components/app/PlanTag.vue
@@ -48,7 +48,7 @@ const props = defineProps({
 const { openSubscriptionModal } = useAppModals()
 const { data: user } = useAuth().user()
 const { current: workspace } = useCurrentWorkspace()
-const { getRequiredTier } = usePlanFeatures()
+const { getRequiredTier, hasFeature } = usePlanFeatures()
 const { currentWorkspaceTier, getTierDisplayName, tierMeetsRequirement } = useBillingUpsell()
 
 // Determine the display tier (either explicit or from feature)
@@ -64,6 +64,7 @@ const shouldDisplayTag = computed(() => {
   if (!isSelfHostedRequired && useFeatureFlag('self_hosted')) return false
   if (!isSelfHostedRequired && !useFeatureFlag('billing.enabled')) return false
   if (!displayTier.value) return false
+  if (props.feature && hasFeature(props.feature)) return false
   if (!user.value || !workspace.value) return true
 
   // Show tag if current tier doesn't meet requirement

--- a/client/components/open/forms/components/form-components/FormCustomSeo.vue
+++ b/client/components/open/forms/components/form-components/FormCustomSeo.vue
@@ -6,7 +6,7 @@
           <h3 class="text-lg font-medium text-neutral-900">
             SEO & Social Sharing - Meta <PlanTag
             class="ml-2"
-            required-tier="business"
+            feature="seo_meta"
             upgrade-modal-title="Upgrade to Enhance Your Form's SEO"
             upgrade-modal-description="Explore advanced SEO features in the editor on our Free plan. Upgrade to fully implement custom meta tags, Open Graph data, and improved search visibility. Boost your form's online presence and attract more respondents with our premium SEO toolkit."
           />

--- a/client/components/open/forms/components/form-components/FormSubmissionSettings.vue
+++ b/client/components/open/forms/components/form-components/FormSubmissionSettings.vue
@@ -108,7 +108,7 @@
               Collect partial submissions
             </span>
             <PlanTag
-              required-tier="business"
+              feature="enable_partial_submissions"
               class="ml-1"
               upgrade-modal-title="Upgrade to collect partial submissions"
               upgrade-modal-description="Capture valuable data from incomplete form submissions. Analyze where users drop off and collect partial information even when they don't complete the entire form."
@@ -129,7 +129,7 @@
           </span>
           <PlanTag
             class="ml-1"
-            required-tier="business"
+            feature="enable_ip_tracking"
             upgrade-modal-title="Upgrade to collect IP addresses"
             upgrade-modal-description="Automatically capture submitter IP addresses to gain valuable insights into your form traffic. Analyze geographic patterns, detect suspicious activity, and enhance your form security with detailed submission analytics."
           />


### PR DESCRIPTION
## What changed

- Made `PlanTag` hide feature-based tags when the current workspace already has access to that feature.
- Switched the form editor labels for partial submissions, IP tracking, and SEO meta from static `business` tags to their actual feature keys.

## Why

AppSumo/grandfathered workspaces can have access to these features through effective workspace features even when their nominal tier is `pro`. The old UI only compared plan tier names, so it showed a misleading `Business` label even though the feature remained available.

## Impact

Users with AppSumo or other grandfathered/override access should no longer see upgrade tags for these three features when they already have access.

## Validation

- `npm run lint` in `client/`