### PR TITLE
Adding inputMode for improved mobile phone UX

### DIFF
--- a/client/components/open/forms/BlockRenderer.vue
+++ b/client/components/open/forms/BlockRenderer.vue
@@ -320,8 +320,14 @@ const boundProps = computed(() => {
     inputProperties.minSlider = parseInt(field.slider_min_value) ?? 0
     inputProperties.maxSlider = parseInt(field.slider_max_value) ?? 50
     inputProperties.stepSlider = parseInt(field.slider_step_value) ?? 5
-  } else if (field.type === 'number' || (field.type === 'phone_number' && field.use_simple_text_input)) {
+  } else if (field.type === 'email') {
+    inputProperties.inputMode = 'email'
+  } else if (field.type === 'url') {
+    inputProperties.inputMode = 'url'
+  } else if (field.type === 'number') {
     inputProperties.pattern = '/d*'
+  } else if (field.type === 'phone_number' && field.use_simple_text_input) {
+    inputProperties.inputMode = 'tel'
   } else if (field.type === 'phone_number' && !field.use_simple_text_input) {
     inputProperties.unavailableCountries = field.unavailable_countries ?? []
   } else if (field.type === 'text' && field.secret_input) {


### PR DESCRIPTION
This change improves the mobile phone experience for end users. Their phone keyboard will pop up with the appropriate settings for the tel, email, and url inputs. For example, on email fields, mobile phone keyboards will show the @ symbol on the first page of the keyboard.

Using inputMode instead of nativeType, per the suggestions from PR 1119.