### PR TITLE
[codex] Fix SEO sitemap and canonical metadata

### DIFF
--- a/client/components/pages/OpenFormFooter.vue
+++ b/client/components/pages/OpenFormFooter.vue
@@ -4,10 +4,6 @@
       <div
         class="relative rounded-4xl overflow-hidden bg-linear-to-br from-blue-600 via-blue-700 to-blue-800 pt-8 sm:pt-10 lg:pt-14 xl:pt-24 pl-8 md:pl-10 lg:pl-14 xl:pl-35"
       >
-        <img
-          src="/img/pages/welcome/powerForm-bg.png"
-          class="absolute min-h-full inset-0 opacity-30"
-        />
         <div class="grid lg:grid-cols-2 relative z-10">
           <div
             class="text-white relative z-20 pr-8 sm:pr-10 md:pr-0 pb-8 sm:pb-10 lg:pb-14 xl:pb-24"

--- a/client/composables/useOpnSeoMeta.js
+++ b/client/composables/useOpnSeoMeta.js
@@ -1,30 +1,133 @@
 import { useSubdomainRedirect } from '~/composables/useSubdomainRedirect'
 
+const nonIndexablePathPatterns = [
+  /^\/admin(?:\/|$)/,
+  /^\/forms\/create(?:\/|$)/,
+  /^\/forms\/[^/]+\/(?:edit|pdf-editor|show)(?:\/|$)/,
+  /^\/home(?:\/|$)/,
+  /^\/login(?:\/|$)/,
+  /^\/password(?:\/|$)/,
+  /^\/redirect(?:\/|$)/,
+  /^\/register(?:\/|$)/,
+  /^\/self-hosted\/checkout(?:\/|$)/,
+  /^\/setup(?:\/|$)/,
+  /^\/subscriptions(?:\/|$)/,
+  /^\/templates\/my-templates(?:\/|$)/,
+]
+
 export const useOpnSeoMeta = (meta, alwaysEnabled = false) => {
   const { shouldRedirect } = useSubdomainRedirect()
+  const route = useRoute()
 
   if (!alwaysEnabled && shouldRedirect()) {
     return
   }
 
-  return useSeoMeta({
-    ...(meta.title
-      ? {
-          ogTitle: meta.title,
-          twitterTitle: meta.title,
-        }
-      : {}),
-    ...(meta.description
-      ? {
-          ogDescription: meta.description,
-          twitterDescription: meta.description,
-        }
-      : {}),
-    ...(meta.ogImage
-      ? {
-          twitterImage: meta.ogImage,
-        }
-      : {}),
-    ...meta,
+  const seoMeta = { ...meta }
+  delete seoMeta.canonical
+
+  useHead(() => {
+    const canonicalUrl = resolveCanonicalUrl(meta.canonical, route)
+
+    return {
+      link: canonicalUrl
+        ? [
+            {
+              key: 'canonical',
+              rel: 'canonical',
+              href: canonicalUrl,
+            },
+          ]
+        : [],
+    }
   })
+
+  return useSeoMeta({
+    ...(seoMeta.title
+      ? {
+          ogTitle: seoMeta.title,
+          twitterTitle: seoMeta.title,
+        }
+      : {}),
+    ...(seoMeta.description
+      ? {
+          ogDescription: seoMeta.description,
+          twitterDescription: seoMeta.description,
+        }
+      : {}),
+    ...(seoMeta.ogImage
+      ? {
+          twitterImage: seoMeta.ogImage,
+        }
+      : {}),
+    ...seoMeta,
+    robots: () => resolveRobots(seoMeta.robots, route),
+  })
+}
+
+function resolveRobots (robots, route) {
+  const resolvedRobots = resolveMetaValue(robots)
+  if (resolvedRobots) {
+    return resolvedRobots
+  }
+
+  return isNonIndexablePath(route.path) ? 'noindex, nofollow' : null
+}
+
+function resolveCanonicalUrl (canonical, route) {
+  const resolvedCanonical = resolveMetaValue(canonical)
+  if (resolvedCanonical === false) {
+    return null
+  }
+
+  if (typeof resolvedCanonical === 'string' && resolvedCanonical) {
+    return normalizeCanonicalUrl(resolvedCanonical)
+  }
+
+  return joinCanonicalUrl(resolveCanonicalBaseUrl(), route.path)
+}
+
+function resolveCanonicalBaseUrl () {
+  const configuredAppUrl = useRuntimeConfig().public.appUrl
+  if (configuredAppUrl && configuredAppUrl !== '/') {
+    return configuredAppUrl
+  }
+
+  if (import.meta.server) {
+    const event = useRequestEvent()
+    const forwardedHost = event?.node.req.headers['x-forwarded-host']
+    const host = forwardedHost || event?.node.req.headers.host
+    const protocol = event?.node.req.headers['x-forwarded-proto'] || 'https'
+
+    return host ? `${protocol}://${host}` : ''
+  }
+
+  return import.meta.client ? window.location.origin : ''
+}
+
+function normalizeCanonicalUrl (url) {
+  if (/^https?:\/\//.test(url)) {
+    return url
+  }
+
+  return joinCanonicalUrl(resolveCanonicalBaseUrl(), url)
+}
+
+function joinCanonicalUrl (baseUrl, path) {
+  if (!baseUrl) {
+    return null
+  }
+
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, '')
+  const normalizedPath = path === '/' ? '/' : `/${path.replace(/^\/+|\/+$/g, '')}`
+
+  return `${normalizedBaseUrl}${normalizedPath}`
+}
+
+function isNonIndexablePath (path) {
+  return nonIndexablePathPatterns.some((pattern) => pattern.test(path))
+}
+
+function resolveMetaValue (value) {
+  return typeof value === 'function' ? value() : value
 }

--- a/client/public/robots.txt
+++ b/client/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Disallow:
+
+Sitemap: https://opnform.com/sitemap.xml

--- a/client/sitemap.js
+++ b/client/sitemap.js
@@ -3,6 +3,7 @@ import templateTypes from './data/forms/templates/types.json'
 import opnformConfig from './opnform.config.js'
 
 const apiBaseUrl = process.env.NUXT_PUBLIC_API_BASE || process.env.NUXT_PRIVATE_API_BASE || ''
+const sitemapLastmod = process.env.NUXT_PUBLIC_SITEMAP_LASTMOD || new Date().toISOString()
 
 export default {
   exclude: [
@@ -44,6 +45,7 @@ function getTemplateTypesUrls () {
   return Object.values(templateTypes).map((feature) => {
     return {
       url: `/templates/types/${feature.slug}`,
+      lastmod: sitemapLastmod,
       changefreq: 'monthly',
       priority: 0.8
     }
@@ -54,6 +56,7 @@ function getTemplateIndustriesUrls () {
   return Object.values(templateIndustries).map((feature) => {
     return {
       url: `/templates/industries/${feature.slug}`,
+      lastmod: sitemapLastmod,
       changefreq: 'monthly',
       priority: 0.8
     }
@@ -80,6 +83,7 @@ async function getIntegrationsPages () {
       if (!slug || !published) return null
       return {
         url: `/integrations/${slug}`,
+        lastmod: page.LastEdited ?? page.lastEdited ?? page.lastmod ?? sitemapLastmod,
         changefreq: 'monthly',
         priority: 0.9
       }

--- a/client/sitemap.js
+++ b/client/sitemap.js
@@ -2,9 +2,24 @@ import templateIndustries from './data/forms/templates/industries.json'
 import templateTypes from './data/forms/templates/types.json'
 import opnformConfig from './opnform.config.js'
 
+const apiBaseUrl = process.env.NUXT_PUBLIC_API_BASE || process.env.NUXT_PRIVATE_API_BASE || ''
+
 export default {
-  exclude: ['/subscriptions/**', '/templates/my-templates', '/setup'],
-  sources: [`${process.env.NUXT_PUBLIC_API_BASE}sitemap-urls`],
+  exclude: [
+    '/admin',
+    '/forms/create',
+    '/forms/create/guest',
+    '/home',
+    '/login',
+    '/password/**',
+    '/redirect/**',
+    '/register',
+    '/self-hosted/checkout/**',
+    '/setup',
+    '/subscriptions/**',
+    '/templates/my-templates',
+  ],
+  sources: apiBaseUrl ? [joinUrl(apiBaseUrl, 'sitemap-urls')] : [],
   cacheMaxAgeSeconds: 60 * 60 * 2, // 2 hours
   xslColumns: [
     { label: 'URL', width: '50%' },
@@ -19,6 +34,10 @@ export default {
       ...(await getIntegrationsPages().catch(() => [])),
     ]
   }
+}
+
+function joinUrl (baseUrl, path) {
+  return `${baseUrl.replace(/\/+$/, '')}/${path.replace(/^\/+/, '')}`
 }
 
 function getTemplateTypesUrls () {


### PR DESCRIPTION
## Summary
- Fix the sitemap API source URL join so `NUXT_PUBLIC_API_BASE=https://api.opnform.com` resolves to `https://api.opnform.com/sitemap-urls`.
- Exclude app/auth/checkout routes from the sitemap and add central noindex handling for those non-SEO paths.
- Add canonical link generation through `useOpnSeoMeta`, with support for absolute or relative overrides.
- Remove the unused footer `powerForm-bg.png` image and its markup.

## Validation
- `npm run lint`
- `npm run build`

Notes: build passes with existing project warnings around circular chunks, stale Browserslist data, Sentry auth token absence, and CSS minify warnings.
