### PR TITLE
[codex] Add self-hosted licensing docs

### DIFF
--- a/client/components/open/forms/components/form-components/FormCustomCode.vue
+++ b/client/components/open/forms/components/form-components/FormCustomCode.vue
@@ -111,7 +111,7 @@ const customCodeHelp = computed(() => {
   }
   // In self-hosted mode with flag disabled (and no custom domain), show safety notice with docs link
   if (isSelfHosted.value && !allowSelfHosted && !hasCustomDomain) {
-    return 'Custom code is disabled for safety on self-hosted. Enable via CUSTOM_CODE_ENABLE_SELF_HOSTED=true. See technical docs: https://docs.opnform.com/introduction'
+    return 'Custom code is disabled for safety on self-hosted. Enable via CUSTOM_CODE_ENABLE_SELF_HOSTED=true. See technical docs: https://docs.opnform.com/deployment/enterprise-features/custom-code'
   }
   return 'Custom code requires to be using a custom domain.'
 })

--- a/client/components/workspaces/settings/CustomCode.vue
+++ b/client/components/workspaces/settings/CustomCode.vue
@@ -169,7 +169,7 @@ const customCodeHelp = computed(() => {
     return 'Saves changes and visit any form page to test. Workspace code is applied to all forms in this workspace.'
   }
   if (isSelfHosted.value && !allowSelfHosted.value && !hasCustomDomain.value) {
-    return 'Custom code is disabled for safety on self-hosted. Enable via CUSTOM_CODE_ENABLE_SELF_HOSTED=true. See technical docs: https://docs.opnform.com/introduction'
+    return 'Custom code is disabled for safety on self-hosted. Enable via CUSTOM_CODE_ENABLE_SELF_HOSTED=true. See technical docs: https://docs.opnform.com/deployment/enterprise-features/custom-code'
   }
   return 'Custom code requires a Pro plan and a custom domain configured for this workspace.'
 })

--- a/client/components/workspaces/settings/Emails.vue
+++ b/client/components/workspaces/settings/Emails.vue
@@ -4,7 +4,7 @@
       <div>
         <h3 class="text-lg font-medium text-neutral-900">Email Settings</h3>
         <p class="mt-1 text-sm text-neutral-500">
-          Customize email sender - connect your SMTP server.
+          Configure a custom SMTP sender for this workspace.
         </p>
         <PlanTag
           required-tier="self_hosted"
@@ -19,6 +19,23 @@
         @click="crisp.openHelpdeskArticle('how-to-send-emails-using-your-own-domain-name-and-email-address-13kkcif')"
       />
     </div>
+
+    <UAlert
+      v-if="isSelfHosted"
+      icon="i-heroicons-information-circle"
+      color="info"
+      variant="subtle"
+      title="Instance-wide email sending is configured separately"
+      description="Use MAIL_* environment variables to configure the default sender for your whole self-hosted instance. These workspace settings override that sender for this workspace and require a self-hosted Enterprise license."
+      :actions="[{
+        label: 'Email setup docs',
+        icon: 'i-heroicons-arrow-top-right-on-square',
+        color: 'info',
+        variant: 'solid',
+        to: 'https://docs.opnform.com/configuration/email-setup',
+        target: '_blank'
+      }]"
+    />
 
     <UAlert
       v-if="!isSelfHosted && !canAccessSmtp"
@@ -206,4 +223,4 @@ const initEmailSettings = () => {
   emailSettingsForm.password = emailSettings?.password
   emailSettingsForm.sender_address = emailSettings?.sender_address
 }
-</script> 
+</script>

--- a/client/stores/working_form.js
+++ b/client/stores/working_form.js
@@ -63,7 +63,7 @@ export const useWorkingFormStore = defineStore("working_form", {
         actions.push({
           label: 'View docs',
           icon: 'i-heroicons-book-open',
-          onclick: () => { if (import.meta.client) window.open('https://docs.opnform.com/introduction', '_blank') }
+          onclick: () => { if (import.meta.client) window.open('https://docs.opnform.com/deployment/enterprise-features/custom-code', '_blank') }
         })
       } else {
         // Cloud: require custom domain + Crisp help

--- a/docs/configuration/aws-s3.mdx
+++ b/docs/configuration/aws-s3.mdx
@@ -5,6 +5,13 @@ description: OpnForm & File uploads
 
 OpnForm uses [Laravel's filesystem](https://laravel.com/docs/master/filesystem), which provides a powerful abstraction layer for various file storage systems. While AWS S3 is a popular choice, OpnForm supports both local storage and S3-compatible services.
 
+<Info>
+    This guide covers instance-wide file storage configuration for your
+    self-hosted deployment. Enterprise external storage features are separate
+    workspace or organization-level controls. See [External
+    Storage](/deployment/enterprise-features/external-storage).
+</Info>
+
 1. Create an S3 bucket in your AWS account (or use an equivalent service).
 
 2. Create an IAM user with access to this bucket. Ensure the user has the necessary permissions to read from and write to the bucket.

--- a/docs/configuration/custom-domain.mdx
+++ b/docs/configuration/custom-domain.mdx
@@ -4,6 +4,13 @@ description: Setting up a custom domain for OpnForm
 ---
 
 This page explains how to configure a custom domain for your OpnForm instance.
+
+<Info>
+    This guide covers the instance-wide domain for your self-hosted OpnForm
+    deployment. Workspace or form-level custom domains are configured
+    separately inside OpnForm and are not the same as the instance URL.
+</Info>
+
 ## Custom Domain Setup
 
 To use a custom domain (or subdomain)with OpnForm:

--- a/docs/configuration/email-setup.mdx
+++ b/docs/configuration/email-setup.mdx
@@ -20,7 +20,8 @@ Self-hosted OpnForm has two email configuration levels:
     You do not need workspace email settings to send emails from a self-hosted
     instance. Configure the instance-wide `MAIL_*` variables first, then use
     workspace email settings only when a workspace needs its own SMTP server or
-    sender identity.
+    sender identity. See [Workspace Custom
+    SMTP](/deployment/enterprise-features/workspace-custom-smtp) for details.
 </Info>
 
 ## Supported Mail Drivers
@@ -73,7 +74,8 @@ To configure workspace SMTP settings:
 <Note>
     Workspace email settings do not replace the instance-wide mail
     configuration. Keep the `MAIL_*` variables configured as the default sender
-    and fallback for your instance.
+    and fallback for your instance. Workspace email settings require a
+    self-hosted Enterprise license.
 </Note>
 
 import CloudVersion from "/snippets/cloud-version.mdx";

--- a/docs/configuration/email-setup.mdx
+++ b/docs/configuration/email-setup.mdx
@@ -9,13 +9,27 @@ By default, with a new Docker deployment, the email driver used is `log`, which 
 
 OpnForm uses Laravel's mail system. For more detailed information, you can refer to the [Laravel Mail documentation](https://laravel.com/docs/master/mail).
 
+## Email Configuration Options
+
+Self-hosted OpnForm has two email configuration levels:
+
+-   **Instance-wide email sending**: Configure the default mailer for your whole OpnForm instance with environment variables such as `MAIL_MAILER`, `MAIL_HOST`, and `MAIL_FROM_ADDRESS`. This is the standard setup for sending account emails, notifications, and any form email notification that does not use workspace-specific SMTP settings.
+-   **Workspace email settings**: Configure a custom SMTP server from a workspace's **Email Settings** page. These settings apply only to that workspace and override the instance-wide mailer for that workspace's form email notifications. Workspace email settings are a self-hosted Enterprise feature.
+
+<Info>
+    You do not need workspace email settings to send emails from a self-hosted
+    instance. Configure the instance-wide `MAIL_*` variables first, then use
+    workspace email settings only when a workspace needs its own SMTP server or
+    sender identity.
+</Info>
+
 ## Supported Mail Drivers
 
 Laravel supports various mail drivers, including SMTP, Mailgun, Postmark, Amazon SES, and more. In this guide, we'll focus on setting up SMTP, which is widely used.
 
-## Configuring SMTP Settings
+## Configure Instance-Wide SMTP Settings
 
-To configure SMTP, you need to set the following environment variables in your `.env` file:
+To configure SMTP for the whole instance, set the following environment variables in your backend `.env` file:
 
 | Variable | Description |
 |----------|-------------|
@@ -27,6 +41,40 @@ To configure SMTP, you need to set the following environment variables in your `
 | `MAIL_ENCRYPTION` | The encryption method used by your SMTP server (typically `tls` or `ssl`). |
 | `MAIL_FROM_ADDRESS` | The email address that emails should be sent from. |
 | `MAIL_FROM_NAME` | The name that should appear as the sender of the emails. |
+
+After changing these variables, restart the API container or process so Laravel loads the new mail configuration.
+
+## Configure Workspace SMTP Settings
+
+Workspace email settings let a workspace send its form email notifications through a dedicated SMTP server instead of the instance-wide mailer.
+
+Use workspace email settings when:
+
+-   A customer or internal team needs emails to come from their own domain.
+-   Different workspaces need different SMTP credentials.
+-   You want form notifications for one workspace to use a separate sender reputation or provider.
+
+To configure workspace SMTP settings:
+
+<Steps>
+<Step title="Open workspace settings">
+    Open the workspace where you want to use a custom sender, then go to **Email Settings**.
+</Step>
+
+<Step title="Enter SMTP credentials">
+    Add the SMTP host, port, encryption, username, password, and sender address for that workspace.
+</Step>
+
+<Step title="Save the settings">
+    Save the workspace email settings. Form email notifications from this workspace will use this SMTP server when the workspace has access to the feature.
+</Step>
+</Steps>
+
+<Note>
+    Workspace email settings do not replace the instance-wide mail
+    configuration. Keep the `MAIL_*` variables configured as the default sender
+    and fallback for your instance.
+</Note>
 
 import CloudVersion from "/snippets/cloud-version.mdx";
 

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -45,6 +45,14 @@ There are dedicated configuration pages available for more detailed setup instru
 | `LICENSE_CHECKOUT_CANCEL_URL`    | Cloud checkout cancellation URL used when creating self-hosted Enterprise license Stripe sessions.                                                                                         |
 | `LICENSE_PORTAL_RETURN_URL`      | Return URL used by the Stripe billing portal for self-hosted Enterprise licenses.                                                                                                          |
 
+### Self-hosted Enterprise licensing
+
+Self-hosted Enterprise features are unlocked by activating a license key in the OpnForm UI. Most installations can use the default license API endpoint.
+
+Use the `LICENSE_*` variables only when you need to override checkout, billing portal, or license API URLs for your deployment.
+
+For activation steps and troubleshooting, see [License Activation](../deployment/license-activation).
+
 ### OAuth Integration Environment Variables
 
 OAuth integrations enable user authentication and third-party service connections. OpnForm automatically handles OAuth redirect URLs - you don't need to manually configure redirect URIs in your OAuth applications.

--- a/docs/configuration/oidc-sso.mdx
+++ b/docs/configuration/oidc-sso.mdx
@@ -4,11 +4,10 @@ description: Complete guide to configuring OpenID Connect Single Sign-On for you
 ---
 
 <Info>
-    **Enterprise Feature**: OIDC SSO is part of our Enterprise Edition. During
-    the beta period: - **Self-hosted**: Free to use (no subscription required) -
-    **Cloud**: Available on Pro plan (will move to Enterprise plan soon) This
-    feature helps fund ongoing development and keeps OpnForm sustainable. For
-    more information about Enterprise licensing, see our [Enterprise
+    **Enterprise Feature**: OIDC SSO is part of OpnForm Enterprise. On
+    self-hosted installations, configure an active Enterprise license before
+    creating or updating workspace OIDC connections. For more information about
+    Enterprise licensing, see our [Enterprise
     Terms](https://opnform.com/terms-conditions).
 </Info>
 

--- a/docs/configuration/oidc-sso.mdx
+++ b/docs/configuration/oidc-sso.mdx
@@ -8,7 +8,8 @@ description: Complete guide to configuring OpenID Connect Single Sign-On for you
     self-hosted installations, configure an active Enterprise license before
     creating or updating workspace OIDC connections. For more information about
     Enterprise licensing, see our [Enterprise
-    Terms](https://opnform.com/terms-conditions).
+    Terms](https://opnform.com/terms-conditions) and [License
+    Activation](/deployment/license-activation).
 </Info>
 
 OpnForm supports OpenID Connect (OIDC) based Single Sign-On (SSO), allowing users to authenticate using their organization's identity provider (IdP) such as Azure Entra ID, Authentik, Okta, or any OIDC-compliant provider.

--- a/docs/deployment/cloud-vs-self-hosting.mdx
+++ b/docs/deployment/cloud-vs-self-hosting.mdx
@@ -10,7 +10,7 @@ When deciding between using OpnForm's cloud service or self-hosting, it's import
 | High availability servers      | \~$50+/month                        | ✅                                 |
 | Load balancer                  | \~$15+/month                        | ✅                                 |
 | Managed database               | \~$45-70+/month                     | ✅                                 |
-| SMTP server                    | \~$15+/month                        | ✅                                 |
+| Instance-wide SMTP provider    | \~$15+/month                        | ✅                                 |
 | Support                        | Discord                    | Live Chat                     |
 | Setup time                     | Manual                              | ✅ Up and running in minutes       |
 | Upgrades                       | Manual                              | ✅ Automatic                       |

--- a/docs/deployment/cloud-vs-self-hosting.mdx
+++ b/docs/deployment/cloud-vs-self-hosting.mdx
@@ -5,6 +5,13 @@ description: "Understand the differences between cloud and self-hosting options 
 
 When deciding between using OpnForm's cloud service or self-hosting, it's important to understand the key differences and benefits of each option. Below is a comparison to help you make an informed decision:
 
+<Info>
+    Self-hosting OpnForm does not require an Enterprise license for core
+    functionality. Some advanced workspace features require a self-hosted
+    Enterprise license. See [Self-hosted
+    License](/deployment/self-hosted-license).
+</Info>
+
 |                         | Self-Hosted                         | OpnForm Cloud                      |
 | ------------------------------ | ----------------------------------- | ---------------------------------- |
 | High availability servers      | \~$50+/month                        | ✅                                 |

--- a/docs/deployment/docker.mdx
+++ b/docs/deployment/docker.mdx
@@ -55,6 +55,12 @@ After deployment, OpnForm will automatically redirect you to a setup page where 
     complete. Use the admin account to invite additional users.
 </Note>
 
+<Info>
+    A self-hosted Enterprise license is optional. Core self-hosted OpnForm works
+    without a license, while advanced Enterprise features require license
+    activation. See [Self-hosted License](/deployment/self-hosted-license).
+</Info>
+
 ## Architecture
 
 ```mermaid

--- a/docs/deployment/enterprise-features/audit-logs.mdx
+++ b/docs/deployment/enterprise-features/audit-logs.mdx
@@ -1,0 +1,29 @@
+---
+title: Audit Logs
+description: Use Enterprise audit and compliance visibility on self-hosted OpnForm
+---
+
+Audit Logs are Enterprise features for teams that need stronger operational and compliance visibility.
+
+## What this unlocks
+
+Depending on your license and OpnForm version, audit and compliance features can help teams track important activity across workspaces and forms.
+
+Use audit-oriented features when you need:
+
+-   Better visibility into administrative changes
+-   Compliance-oriented activity records
+-   Operational review of sensitive workspace changes
+
+## Before you start
+
+Make sure you have:
+
+-   An active self-hosted Enterprise license with audit features enabled
+-   Workspace or instance admin access
+-   Internal retention and access policies for audit data
+
+## Related pages
+
+-   [Self-hosted License](/deployment/self-hosted-license)
+-   [License Activation](/deployment/license-activation)

--- a/docs/deployment/enterprise-features/custom-code.mdx
+++ b/docs/deployment/enterprise-features/custom-code.mdx
@@ -1,0 +1,44 @@
+---
+title: Custom Code
+description: Use workspace and form custom code on self-hosted OpnForm
+---
+
+Custom Code lets you inject scripts or CSS into forms for advanced tracking, styling, and integrations.
+
+<Warning>
+    Custom code can execute JavaScript on public form pages. Enable it only
+    when you trust the workspace admins who can edit forms and workspace
+    settings.
+</Warning>
+
+## What this unlocks
+
+Depending on your license and instance configuration, Custom Code can unlock:
+
+-   Workspace-level custom code
+-   Form-level custom code
+-   Custom CSS for advanced form styling
+-   Advanced tracking scripts and SDK integrations
+
+## Self-hosted safety setting
+
+Self-hosted deployments keep custom code disabled by default for safety. To allow custom code execution on self-hosted forms, set:
+
+```bash
+CUSTOM_CODE_ENABLE_SELF_HOSTED=true
+```
+
+After changing this value, recreate the affected Docker containers so the new environment variable is loaded.
+
+<Info>
+    The environment variable controls whether custom code can execute on
+    self-hosted forms. The Enterprise license controls whether the workspace can
+    access the underlying advanced branding and custom code features.
+</Info>
+
+## Related pages
+
+-   [JavaScript SDK](/embedding/javascript-sdk)
+-   [Environment Variables](/configuration/environment-variables)
+-   [Self-hosted License](/deployment/self-hosted-license)
+-   [License Activation](/deployment/license-activation)

--- a/docs/deployment/enterprise-features/external-storage.mdx
+++ b/docs/deployment/enterprise-features/external-storage.mdx
@@ -1,0 +1,28 @@
+---
+title: External Storage
+description: Understand Enterprise external storage controls for self-hosted OpnForm
+---
+
+External Storage is an Enterprise area for teams that need storage controls beyond the instance-wide default.
+
+<Info>
+    Instance-wide file storage configuration, including local and
+    S3-compatible storage, is configured separately and does not require an
+    Enterprise license by itself.
+</Info>
+
+## Instance-wide storage vs Enterprise external storage
+
+Self-hosted OpnForm can use Laravel filesystem configuration to store uploads locally or in S3-compatible storage. This is the default storage configuration for the whole instance.
+
+Enterprise external storage features are workspace or organization-level controls that go beyond the default instance storage setup.
+
+## Configure instance-wide file storage
+
+See [AWS S3 Configuration](/configuration/aws-s3) for the standard self-hosted storage setup.
+
+## Related pages
+
+-   [AWS S3 Configuration](/configuration/aws-s3)
+-   [Self-hosted License](/deployment/self-hosted-license)
+-   [License Activation](/deployment/license-activation)

--- a/docs/deployment/enterprise-features/multiple-workspaces.mdx
+++ b/docs/deployment/enterprise-features/multiple-workspaces.mdx
@@ -1,0 +1,28 @@
+---
+title: Multiple Workspaces and Team Roles
+description: Use Enterprise multi-workspace and team role controls on self-hosted OpnForm
+---
+
+Self-hosted Enterprise can unlock workspace and team administration features for organizations that manage several teams, clients, or departments in one OpnForm instance.
+
+## What this unlocks
+
+Depending on the features included in your license, multi-org access can unlock:
+
+-   Multiple workspaces
+-   Advanced workspace member roles
+-   Higher-level organization controls around workspace administration
+
+## Before you start
+
+Make sure you have:
+
+-   An active self-hosted Enterprise license with multi-org features enabled
+-   Workspace admin access
+-   A clear workspace structure for your teams or clients
+
+## Related pages
+
+-   [Self-hosted License](/deployment/self-hosted-license)
+-   [License Activation](/deployment/license-activation)
+-   [Workspace Users API](/api-reference/workspace-users/list-workspace-users)

--- a/docs/deployment/enterprise-features/single-sign-on.mdx
+++ b/docs/deployment/enterprise-features/single-sign-on.mdx
@@ -1,0 +1,34 @@
+---
+title: Single Sign-On
+description: Use Enterprise SSO features on self-hosted OpnForm
+---
+
+Self-hosted Enterprise can unlock SSO features for teams that need centralized identity management.
+
+## What this unlocks
+
+Enterprise SSO covers:
+
+-   OIDC SSO
+-   SAML SSO
+-   LDAP SSO
+
+OIDC configuration is currently documented in detail. SAML and LDAP availability depends on the Enterprise features enabled for your installation.
+
+## Before you start
+
+Make sure you have:
+
+-   An active self-hosted Enterprise license with SSO enabled
+-   Workspace admin access
+-   Identity provider credentials and allowed redirect URI configuration
+
+## Configure OIDC SSO
+
+See [OIDC SSO Configuration](/configuration/oidc-sso) for provider setup, redirect URI behavior, field mappings, group-to-role mappings, and force login mode.
+
+## Related pages
+
+-   [OIDC SSO Configuration](/configuration/oidc-sso)
+-   [Self-hosted License](/deployment/self-hosted-license)
+-   [License Activation](/deployment/license-activation)

--- a/docs/deployment/enterprise-features/white-label-branding.mdx
+++ b/docs/deployment/enterprise-features/white-label-branding.mdx
@@ -1,0 +1,33 @@
+---
+title: White Label and Advanced Branding
+description: Remove OpnForm branding and use advanced branding controls on self-hosted OpnForm
+---
+
+Self-hosted Enterprise can unlock white-label and advanced branding controls for teams that need a more controlled brand experience.
+
+## What this unlocks
+
+Depending on your license, white-label access can unlock:
+
+-   Branding removal
+-   Advanced form branding
+-   Custom CSS and branding controls
+-   White-label presentation options
+
+## Community branding vs Enterprise branding
+
+Community self-hosted installations include core form customization. Enterprise white-label features unlock deeper workspace-level branding and branding removal controls.
+
+## Before you start
+
+Make sure you have:
+
+-   An active self-hosted Enterprise license with white-label features enabled
+-   Workspace admin access
+-   Brand assets and CSS ready if you plan to customize styling
+
+## Related pages
+
+-   [Self-hosted License](/deployment/self-hosted-license)
+-   [License Activation](/deployment/license-activation)
+-   [Custom Code](/deployment/enterprise-features/custom-code)

--- a/docs/deployment/enterprise-features/workspace-custom-smtp.mdx
+++ b/docs/deployment/enterprise-features/workspace-custom-smtp.mdx
@@ -1,0 +1,56 @@
+---
+title: Workspace Custom SMTP
+description: Use dedicated SMTP credentials for a specific OpnForm workspace
+---
+
+Workspace Custom SMTP lets a workspace send form email notifications through its own SMTP server instead of the instance-wide mailer.
+
+<Info>
+    Workspace Custom SMTP is a self-hosted Enterprise feature. Instance-wide
+    email sending with `MAIL_*` environment variables remains available without
+    an Enterprise license.
+</Info>
+
+## What this unlocks
+
+Use Workspace Custom SMTP when:
+
+-   A workspace needs emails to come from its own domain.
+-   Different workspaces need different SMTP credentials.
+-   You want to separate sender reputation or delivery providers by workspace.
+
+## Before you start
+
+Make sure you have:
+
+-   An active self-hosted Enterprise license with Workspace Custom SMTP enabled
+-   Workspace admin access
+-   SMTP host, port, encryption, username, password, and sender address
+
+## Configure Workspace Custom SMTP
+
+<Steps>
+<Step title="Open workspace settings">
+    Open the workspace that needs its own sender, then go to **Email Settings**.
+</Step>
+
+<Step title="Enter SMTP settings">
+    Enter the SMTP host, port, encryption, username, password, and sender address.
+</Step>
+
+<Step title="Save the settings">
+    Save the workspace email settings. Form email notifications from this workspace will use these SMTP credentials when the feature is available.
+</Step>
+</Steps>
+
+## How it relates to instance-wide email
+
+The instance-wide `MAIL_*` configuration is still the default mailer for your self-hosted instance. Workspace Custom SMTP only overrides email sending for the workspace where it is configured.
+
+See [Email Setup](/configuration/email-setup) for the full comparison.
+
+## Related pages
+
+-   [Email Setup](/configuration/email-setup)
+-   [Self-hosted License](/deployment/self-hosted-license)
+-   [License Activation](/deployment/license-activation)

--- a/docs/deployment/license-activation.mdx
+++ b/docs/deployment/license-activation.mdx
@@ -1,0 +1,96 @@
+---
+title: License Activation
+description: Activate a self-hosted Enterprise license on your OpnForm installation
+---
+
+Use a self-hosted Enterprise license key to unlock Enterprise features on your OpnForm instance.
+
+## Prerequisites
+
+Before activating a license, make sure you have:
+
+-   A running self-hosted OpnForm installation
+-   A user account that is an admin of at least one workspace
+-   A self-hosted Enterprise license key
+-   Network access from your API container or server to the OpnForm license API
+
+By default, self-hosted license validation uses `https://api.opnform.com`.
+
+## Activate a license from the UI
+
+<Steps>
+<Step title="Open user settings">
+    Sign in as a workspace admin, then open your user settings.
+</Step>
+
+<Step title="Open Enterprise License">
+    Go to the **Enterprise License** section.
+</Step>
+
+<Step title="Enter your license key">
+    Paste your license key in the **License Key** field.
+</Step>
+
+<Step title="Activate the license">
+    Click **Activate License**. When activation succeeds, OpnForm refreshes the instance feature flags and enables the licensed Enterprise features.
+</Step>
+</Steps>
+
+## License-related environment variables
+
+Most installations can use the default license API settings. Override these variables only when instructed by OpnForm support or when you run a custom license API endpoint.
+
+| Variable | Description |
+| -------- | ----------- |
+| `LICENSE_API_ENDPOINT` | Backend license API endpoint. Defaults to `https://api.opnform.com`. |
+| `LICENSE_CHECKOUT_SUCCESS_URL` | Checkout success URL used when creating self-hosted Enterprise license checkout sessions. |
+| `LICENSE_CHECKOUT_CANCEL_URL` | Checkout cancellation URL used when creating self-hosted Enterprise license checkout sessions. |
+| `LICENSE_PORTAL_RETURN_URL` | Return URL used by the billing portal for self-hosted Enterprise licenses. |
+| `NUXT_PUBLIC_LICENSE_API_ENDPOINT` | Front-end license API endpoint used to start Enterprise license checkout. Defaults to `https://api.opnform.com`. |
+
+<Warning>
+    After changing environment variables, recreate the affected Docker
+    containers. A simple restart does not reload Docker environment variables.
+</Warning>
+
+## Network requirements
+
+The API validates the installed license with the configured license API endpoint. The instance sends its license key, instance identifier, and usage metadata needed to validate the license.
+
+OpnForm caches license checks. If the license API is temporarily unavailable after a successful check, the instance can enter a short grace state and continue using licensed features while it retries validation.
+
+## License statuses
+
+| Status | Meaning |
+| ------ | ------- |
+| `active` | The license is valid and Enterprise features are enabled. |
+| `grace` | The last successful check is still within the grace window after a temporary license API failure. |
+| `expired` | The license is no longer active. Enterprise features are disabled until renewal or activation of a valid key. |
+| `activation_limit_reached` | The key is already activated on another self-hosted instance. Contact support to reset the activation. |
+| `invalid` | The key is missing, invalid, or could not be validated. |
+
+## Troubleshooting
+
+<AccordionGroup>
+<Accordion title="The license key is invalid or expired">
+    Confirm that you copied the full key and that the license is active. If the key still fails, contact OpnForm support.
+</Accordion>
+
+<Accordion title="The activation limit was reached">
+    A self-hosted license key is tied to an instance activation. Contact support if you migrated servers or need the activation reset.
+</Accordion>
+
+<Accordion title="Enterprise features are still locked after activation">
+    Refresh the page and sign in again. If features remain locked, confirm that the API can reach the configured `LICENSE_API_ENDPOINT`, then recreate containers if you changed environment variables.
+</Accordion>
+
+<Accordion title="The billing portal does not open">
+    Make sure a valid license key is installed and that the API can reach the license API endpoint.
+</Accordion>
+</AccordionGroup>
+
+## Related pages
+
+-   [Self-hosted License](/deployment/self-hosted-license)
+-   [Environment Variables](/configuration/environment-variables)
+-   [Docker Environment Variables](/configuration/environment-variables#docker-environment-variables)

--- a/docs/deployment/self-hosted-license.mdx
+++ b/docs/deployment/self-hosted-license.mdx
@@ -1,0 +1,92 @@
+---
+title: Self-hosted License
+description: Understand Community and Enterprise features for self-hosted OpnForm installations
+---
+
+OpnForm is open-source and licensed under AGPLv3. You can self-host the core product without an Enterprise license.
+
+OpnForm also includes Enterprise features under a separate Enterprise License. These features are built for teams that need stronger identity controls, branding, auditability, and workspace-level administration while helping fund ongoing development of the open-source project.
+
+<Info>
+    Enterprise code is included with the OpnForm repository and Docker images,
+    but Enterprise features require an active self-hosted Enterprise license to
+    use.
+</Info>
+
+## When do I need a license?
+
+| Capability | Community self-hosted | Self-hosted Enterprise |
+| ---------- | --------------------- | ---------------------- |
+| Run OpnForm for personal use | Yes | Yes |
+| Run OpnForm for commercial use | Yes | Yes |
+| Modify the AGPLv3 core and redistribute under AGPLv3 | Yes | Yes |
+| Use core form builder features | Yes | Yes |
+| Configure instance-wide SMTP, storage, domains, and OAuth | Yes | Yes |
+| Use Enterprise workspace features | No | Yes |
+| Use Enterprise support and licensing terms | No | Yes |
+
+## What is included in Community self-hosted?
+
+Community self-hosted installations include the core OpnForm product:
+
+-   Core form builder and public form pages
+-   Form submissions and exports
+-   Embeds and the JavaScript SDK
+-   Webhooks and standard integrations available in your deployment
+-   Instance-wide email sending with `MAIL_*` environment variables
+-   Instance-wide domain configuration with `APP_URL`, `FRONT_URL`, and your reverse proxy
+-   Instance-wide file storage configuration, including local and S3-compatible storage
+-   Standard authentication and OAuth providers configured with environment variables
+
+The exact limits depend on your infrastructure and on the product features enabled in your version of OpnForm.
+
+## What is included in self-hosted Enterprise?
+
+Self-hosted Enterprise unlocks advanced workspace and organization controls:
+
+| Enterprise area | What it unlocks |
+| --------------- | --------------- |
+| SSO | OIDC, SAML, and LDAP single sign-on features |
+| Multi-org | Multiple workspaces and advanced team role features |
+| White label | Branding removal, advanced branding, and white-label controls |
+| Workspace Custom SMTP | Dedicated SMTP settings for individual workspaces |
+| Audit logs | Audit and compliance-oriented visibility features |
+| External storage | Enterprise storage controls beyond the instance-wide default |
+| Custom code | Workspace and form custom code when enabled for self-hosted deployments |
+
+<Note>
+    Your license key controls which Enterprise areas are enabled. Some licenses
+    may include a subset of Enterprise features.
+</Note>
+
+## Instance configuration vs Enterprise workspace features
+
+Some OpnForm settings exist at two levels. The instance-wide configuration is available to self-hosted installations without an Enterprise license. The workspace-level Enterprise feature gives specific workspaces their own dedicated controls.
+
+| Area | Community instance-wide configuration | Enterprise workspace feature |
+| ---- | ------------------------------------- | ---------------------------- |
+| Email | Configure the default sender with `MAIL_*` variables | Configure Workspace Custom SMTP for a specific workspace |
+| Storage | Configure the default filesystem or S3-compatible storage | Use Enterprise external storage controls when available |
+| Branding | Use core form customization options | Remove OpnForm branding and use advanced white-label controls |
+| Authentication | Use standard login and configured OAuth providers | Use OIDC, SAML, or LDAP SSO |
+
+<Note>
+    Custom domains can also exist at two levels: the domain for your whole
+    OpnForm instance, and custom domains attached to workspaces or forms. See
+    [Using your own domain](/configuration/custom-domain) for the instance-wide
+    setup.
+</Note>
+
+## Activate Enterprise features
+
+To unlock Enterprise features on a self-hosted instance, activate a license key in OpnForm.
+
+See [License Activation](/deployment/license-activation) for setup steps, network requirements, and troubleshooting.
+
+## Related pages
+
+-   [License Activation](/deployment/license-activation)
+-   [Workspace Custom SMTP](/deployment/enterprise-features/workspace-custom-smtp)
+-   [Single Sign-On](/deployment/enterprise-features/single-sign-on)
+-   [Email Setup](/configuration/email-setup)
+-   [Environment Variables](/configuration/environment-variables)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -32,7 +32,21 @@
               "deployment/docker",
               "deployment/docker-development",
               "deployment/local-deployment",
-              "deployment/cloud-vs-self-hosting"
+              "deployment/cloud-vs-self-hosting",
+              "deployment/self-hosted-license",
+              "deployment/license-activation"
+            ]
+          },
+          {
+            "group": "Self-hosted Enterprise",
+            "pages": [
+              "deployment/enterprise-features/workspace-custom-smtp",
+              "deployment/enterprise-features/single-sign-on",
+              "deployment/enterprise-features/multiple-workspaces",
+              "deployment/enterprise-features/white-label-branding",
+              "deployment/enterprise-features/custom-code",
+              "deployment/enterprise-features/audit-logs",
+              "deployment/enterprise-features/external-storage"
             ]
           },
           {

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -9,6 +9,12 @@ OpnForm is an open-source form builder designed to empower developers and users 
 
 <Note>For end-user documentation, feature explanations, and usage guides, please refer to our [Help Center](https://help.opnform.com).</Note>
 
+<Info>
+  Self-hosted OpnForm can be used without an Enterprise license for core
+  functionality. Advanced self-hosted features require license activation. See
+  [Self-hosted License](/deployment/self-hosted-license).
+</Info>
+
 <CardGroup cols={2}>
   <Card title="Cloud Version" icon="cloud" href="https://opnform.com/?utm_source=docs&utm_medium=introduction&utm_campaign=cloud_version">
     Managed service with high availability and security.


### PR DESCRIPTION
## Summary
- Add canonical self-hosted licensing documentation with Community vs Enterprise coverage and an instance-wide vs workspace-feature comparison.
- Add a License Activation guide covering UI activation, license env vars, statuses, network requirements, and troubleshooting.
- Add Self-hosted Enterprise feature pages for Workspace Custom SMTP, SSO, multi-workspace/team roles, white label branding, custom code, audit logs, and external storage.
- Clarify existing SMTP, OIDC, domain, storage, Docker, cloud-vs-self-hosting, intro, and environment variable docs with links to the new licensing pages.
- Update in-app Custom Code docs links to point to the new Custom Code Enterprise page.

## Validation
- npm run lint
- node -e "JSON.parse(require('fs').readFileSync('docs/docs.json','utf8')); console.log('docs.json ok')"
- git diff --check