### PR TITLE
[codex] Allow self-hosted OIDC within free user limit

### DIFF
--- a/api/app/Enterprise/Oidc/Policies/IdentityConnectionPolicy.php
+++ b/api/app/Enterprise/Oidc/Policies/IdentityConnectionPolicy.php
@@ -7,7 +7,6 @@ use App\Service\Billing\Feature;
 use App\Models\User;
 use App\Models\Workspace;
 use App\Policies\WorkspacePolicy;
-use App\Service\License\LicenseService;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class IdentityConnectionPolicy
@@ -97,15 +96,15 @@ class IdentityConnectionPolicy
     }
 
     /**
-     * Check if workspace has OIDC access (always true for self-hosted).
+     * Check if workspace has OIDC access.
      */
     protected function hasOidcAccess(Workspace $workspace): bool
     {
-        if (!pricing_enabled()) {
-            if (config('app.self_hosted')) {
-                return app(LicenseService::class)->hasFeature('sso');
-            }
+        if (config('app.self_hosted')) {
+            return true;
+        }
 
+        if (!pricing_enabled()) {
             return true;
         }
 

--- a/api/app/Enterprise/Oidc/ProvisioningService.php
+++ b/api/app/Enterprise/Oidc/ProvisioningService.php
@@ -7,6 +7,7 @@ use App\Enterprise\Oidc\Models\IdentityConnection;
 use App\Enterprise\Oidc\Models\UserIdentity;
 use App\Models\User;
 use App\Models\Workspace;
+use App\Service\License\SelfHostedSeatLimitService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Laravel\Socialite\Contracts\User as SocialiteUser;
@@ -84,6 +85,8 @@ class ProvisioningService
                         claims: $idTokenClaims,
                     );
                 }
+
+                app(SelfHostedSeatLimitService::class)->assertCanCreateUser($email);
 
                 // Create new user
                 $userName = $name ?? $socialiteUser->getName() ?? explode('@', $email)[0];

--- a/api/app/Http/Controllers/Auth/RegisterController.php
+++ b/api/app/Http/Controllers/Auth/RegisterController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\UserResource;
 use App\Models\User;
+use App\Service\License\SelfHostedSeatLimitService;
 use App\Service\WorkspaceInviteService;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\RegistersUsers;
@@ -109,6 +110,10 @@ class RegisterController extends Controller
     protected function create(array $data)
     {
         $this->checkRegistrationAllowed($data);
+        if (!array_key_exists('invite_token', $data) || empty($data['invite_token'])) {
+            app(SelfHostedSeatLimitService::class)->assertCanCreateUser($data['email']);
+        }
+
         [$workspace, $role] = app(WorkspaceInviteService::class)->getWorkspaceAndRole($data);
 
         $user = User::create([

--- a/api/app/Service/License/SelfHostedSeatLimitService.php
+++ b/api/app/Service/License/SelfHostedSeatLimitService.php
@@ -11,6 +11,29 @@ class SelfHostedSeatLimitService
 {
     private const FREE_SEAT_LIMIT = 2;
 
+    public function canCreateUser(string $email): bool
+    {
+        if (!$this->shouldEnforceLimit()) {
+            return true;
+        }
+
+        if ($this->hasValidLicense()) {
+            return true;
+        }
+
+        $normalizedEmail = $this->normalizeEmail($email);
+        $activeUserEmails = $this->activeUserEmails();
+        if ($activeUserEmails->contains($normalizedEmail)) {
+            return true;
+        }
+
+        if ($this->pendingInviteEmails()->contains($normalizedEmail)) {
+            return $activeUserEmails->count() < self::FREE_SEAT_LIMIT;
+        }
+
+        return $this->usedSeats() < self::FREE_SEAT_LIMIT;
+    }
+
     public function canInviteEmail(string $email): bool
     {
         if (!$this->shouldEnforceLimit()) {
@@ -44,6 +67,17 @@ class SelfHostedSeatLimitService
         }
 
         return $this->usedSeats($invite) < self::FREE_SEAT_LIMIT;
+    }
+
+    public function assertCanCreateUser(string $email): void
+    {
+        if ($this->canCreateUser($email)) {
+            return;
+        }
+
+        throw new HttpResponseException(
+            response()->json(['message' => $this->limitMessage()], 403)
+        );
     }
 
     public function assertCanInviteEmail(string $email): void

--- a/api/app/Services/Tax/StripeExportDatasetService.php
+++ b/api/app/Services/Tax/StripeExportDatasetService.php
@@ -685,7 +685,7 @@ class StripeExportDatasetService
 
     private function getAccountingLookbackDays(): int
     {
-        return max(0, (int) env('STRIPE_EXPORT_LOOKBACK_DAYS', 45));
+        return max(0, (int) config('services.stripe.export_lookback_days', 45));
     }
 
     private function resolveCustomerId(Invoice $invoice): string

--- a/api/config/plans.php
+++ b/api/config/plans.php
@@ -148,7 +148,7 @@ return [
      * Maps License API feature keys to application feature keys from the 'features' section above.
      */
     'self_hosted_features' => [
-        'sso' => ['sso.oidc', 'sso.saml', 'sso.ldap'],
+        'sso' => ['sso.saml', 'sso.ldap'],
         'multiOrg' => ['workspaces.multiple', 'multi_user.roles'],
         'whitelabel' => ['branding.removal', 'branding.advanced', 'white_label'],
         'custom_smtp' => ['custom_smtp'],

--- a/api/config/services.php
+++ b/api/config/services.php
@@ -89,6 +89,7 @@ return [
         'client_id' => env('STRIPE_CLIENT_ID'),
         'client_secret' => env('STRIPE_CLIENT_SECRET', env('STRIPE_SECRET')),
         'redirect' => env('STRIPE_REDIRECT_URL', front_url('/oauth/stripe/callback')),
+        'export_lookback_days' => env('STRIPE_EXPORT_LOOKBACK_DAYS', 45),
     ],
 
     'ipinfo' => [

--- a/api/tests/Feature/Enterprise/Oidc/IdentityConnectionPolicyTest.php
+++ b/api/tests/Feature/Enterprise/Oidc/IdentityConnectionPolicyTest.php
@@ -128,6 +128,18 @@ describe('IdentityConnectionPolicy', function () {
         expect($policy->create($user, $workspace))->toBeTrue();
     });
 
+    it('allows self-hosted workspace admin to create workspace connection without license', function () {
+        Setting::forget(SettingsKey::SELF_HOSTED_LICENSE);
+        Cache::forget('self_hosted_license_check');
+
+        $user = User::factory()->create();
+        $workspace = Workspace::factory()->create();
+        $user->workspaces()->attach($workspace->id, ['role' => 'admin']);
+        $policy = new IdentityConnectionPolicy();
+
+        expect($policy->create($user, $workspace))->toBeTrue();
+    });
+
     it('prevents non-admin from creating workspace connection', function () {
         $user = User::factory()->create();
         $workspace = Workspace::factory()->create();

--- a/api/tests/Feature/Enterprise/Oidc/OidcConnectionControllerTest.php
+++ b/api/tests/Feature/Enterprise/Oidc/OidcConnectionControllerTest.php
@@ -135,6 +135,32 @@ describe('OidcConnectionController - Create Connection', function () {
         expect($response->json('client_secret'))->toBeNull(); // Should not expose secret
     });
 
+    it('creates workspace-scoped connection on self-hosted without license', function () {
+        Setting::forget(SettingsKey::SELF_HOSTED_LICENSE);
+        Cache::forget('self_hosted_license_check');
+
+        $user = User::factory()->create(['email' => 'user@company.com']);
+        $this->actingAs($user);
+
+        $workspace = Workspace::factory()->create();
+        $user->workspaces()->attach($workspace->id, ['role' => 'admin']);
+
+        $data = [
+            'name' => 'Company SSO',
+            'slug' => 'company-sso',
+            'domain' => 'company.com',
+            'issuer' => 'https://idp.company.com',
+            'client_id' => 'client-123',
+            'client_secret' => 'secret-456',
+            'enabled' => true,
+        ];
+
+        $response = $this->postJson("/open/workspaces/{$workspace->id}/oidc-connections", $data);
+
+        $response->assertStatus(201);
+        expect($response->json('name'))->toBe('Company SSO');
+    });
+
     it('validates required fields', function () {
         $user = $this->actingAsEnterpriseUser();
         $workspace = Workspace::factory()->create();

--- a/api/tests/Feature/Enterprise/Oidc/ProvisioningServiceTest.php
+++ b/api/tests/Feature/Enterprise/Oidc/ProvisioningServiceTest.php
@@ -5,6 +5,9 @@ use App\Enterprise\Oidc\Models\UserIdentity;
 use App\Enterprise\Oidc\ProvisioningService;
 use App\Models\User;
 use App\Models\Workspace;
+use App\Service\License\LicenseCheckResult;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Support\Facades\Cache;
 use Tests\TestHelpers;
 
 require_once __DIR__ . '/../../../TestHelpers/OidcTestHelpers.php';
@@ -80,6 +83,89 @@ describe('ProvisioningService - New User Creation', function () {
         // Current implementation: $name ?? $socialiteUser->getName() ?? explode('@', $email)[0]
         // Since $name will be null (all fields unset), it should use email prefix
         expect($user->name)->toBe('noname');
+    });
+});
+
+describe('ProvisioningService - Self-hosted seat limits', function () {
+    beforeEach(function () {
+        config(['app.self_hosted' => true]);
+        config(['cashier.key' => null]);
+        Cache::forget('self_hosted_license_check');
+    });
+
+    it('blocks OIDC provisioning beyond the free 2 user instance limit', function () {
+        User::factory()->create(['email' => 'owner@example.com']);
+        User::factory()->create(['email' => 'member@example.com']);
+
+        $connection = IdentityConnection::factory()->create();
+        $socialiteUser = createMockSocialiteUser(
+            email: 'third@example.com',
+            name: 'Third User'
+        );
+        $idTokenClaims = createValidIdTokenClaims($connection, 'sub-third');
+
+        $service = app(ProvisioningService::class);
+
+        expect(fn () => $service->provisionUser($connection, $socialiteUser, $idTokenClaims))
+            ->toThrow(HttpResponseException::class);
+
+        expect(User::where('email', 'third@example.com')->exists())->toBeFalse();
+        expect(UserIdentity::where('subject', 'sub-third')->exists())->toBeFalse();
+    });
+
+    it('allows existing OIDC users to sign in when the free user limit is full', function () {
+        User::factory()->create(['email' => 'owner@example.com']);
+        $existingUser = User::factory()->create(['email' => 'existing@example.com']);
+        $connection = IdentityConnection::factory()->create();
+
+        UserIdentity::factory()->create([
+            'user_id' => $existingUser->id,
+            'connection_id' => $connection->id,
+            'subject' => 'sub-existing',
+            'email' => 'existing@example.com',
+        ]);
+
+        $socialiteUser = createMockSocialiteUser(
+            email: 'existing@example.com',
+            name: 'Existing User'
+        );
+        $idTokenClaims = createValidIdTokenClaims($connection, 'sub-existing');
+
+        $service = app(ProvisioningService::class);
+        $user = $service->provisionUser($connection, $socialiteUser, $idTokenClaims);
+
+        expect($user->id)->toBe($existingUser->id);
+    });
+
+    it('allows OIDC provisioning beyond 2 users with an active self-hosted license', function () {
+        User::factory()->create(['email' => 'owner@example.com']);
+        User::factory()->create(['email' => 'member@example.com']);
+        $this->storeSelfHostedLicense([
+            'license_key' => 'lic_oidc_seats_active',
+            'status' => 'active',
+            'features' => ['sso' => true],
+            'last_checked_at' => now()->format('c'),
+            'expires_at' => now()->addYear()->format('c'),
+        ]);
+        Cache::put('self_hosted_license_check', new LicenseCheckResult(
+            status: 'active',
+            features: ['sso' => true],
+            lastChecked: now(),
+            expiresAt: now()->addYear(),
+        ), 86400);
+
+        $connection = IdentityConnection::factory()->create();
+        $socialiteUser = createMockSocialiteUser(
+            email: 'third@example.com',
+            name: 'Third User'
+        );
+        $idTokenClaims = createValidIdTokenClaims($connection, 'sub-third');
+
+        $service = app(ProvisioningService::class);
+        $user = $service->provisionUser($connection, $socialiteUser, $idTokenClaims);
+
+        expect($user->email)->toBe('third@example.com');
+        expect(UserIdentity::where('subject', 'sub-third')->exists())->toBeTrue();
     });
 });
 

--- a/api/tests/Feature/RegisterTest.php
+++ b/api/tests/Feature/RegisterTest.php
@@ -52,6 +52,29 @@ it('cannot register with existing email', function () {
         ->assertJsonValidationErrors(['email']);
 });
 
+it('blocks registering a third user on a free self-hosted instance', function () {
+    config(['app.self_hosted' => true]);
+    config(['cashier.key' => null]);
+
+    User::factory()->create(['email' => 'owner@example.com']);
+    User::factory()->create(['email' => 'member@example.com']);
+
+    $this->postJson('/register', [
+        'name' => 'Third User',
+        'email' => 'third@example.com',
+        'hear_about_us' => 'google',
+        'password' => 'Abcd@1234',
+        'password_confirmation' => 'Abcd@1234',
+        'g-recaptcha-response' => 'test-token',
+    ])
+        ->assertStatus(403)
+        ->assertJson([
+            'message' => 'Enterprise license is required to add more than 2 users to a self-hosted instance.',
+        ]);
+
+    expect(User::where('email', 'third@example.com')->exists())->toBeFalse();
+});
+
 it('cannot register with disposable email', function () {
     Http::fake([
         ValidReCaptcha::RECAPTCHA_VERIFY_URL => Http::response(['success' => true])

--- a/api/tests/Feature/SelfHosted/LicenseServiceTest.php
+++ b/api/tests/Feature/SelfHosted/LicenseServiceTest.php
@@ -312,7 +312,7 @@ describe('hasAppFeature', function () {
 
         $service = app(LicenseService::class);
 
-        expect($service->hasAppFeature('sso.oidc'))->toBeTrue();
+        expect($service->hasAppFeature('sso.oidc'))->toBeFalse();
         expect($service->hasAppFeature('sso.saml'))->toBeTrue();
         expect($service->hasAppFeature('custom_smtp'))->toBeTrue();
         expect($service->hasAppFeature('audit_logs'))->toBeFalse();

--- a/client/components/pages/pricing/FeatureComparison.vue
+++ b/client/components/pages/pricing/FeatureComparison.vue
@@ -237,7 +237,7 @@ const sections = [
         values: [false, true, true, true],
       },
       {
-        label: "SSO (SAML, OIDC, LDAP)",
+        label: "Advanced SSO (SAML/LDAP)",
         values: [false, false, false, true],
       },
     ],

--- a/client/components/pages/pricing/SubscriptionModal.vue
+++ b/client/components/pages/pricing/SubscriptionModal.vue
@@ -294,7 +294,7 @@ const PLAN_DETAILS = {
     ],
     summaryLine: 'Best when security, compliance, and centralized access control are non-negotiable.',
     features: [
-      { icon: 'heroicons:shield-check', title: 'Enterprise SSO', description: 'Connect OIDC, SAML, or LDAP so access is controlled from your identity provider.' },
+      { icon: 'heroicons:shield-check', title: 'Enterprise SSO', description: 'Connect SAML or LDAP so access is controlled from your identity provider.' },
       { icon: 'heroicons:document-text', title: 'Audit logs & compliance', description: 'Track important activity and support teams that need stronger internal controls.' },
       { icon: 'heroicons:server-stack', title: 'External storage', description: 'Route storage to your own infrastructure when you need tighter operational ownership.' },
     ],
@@ -304,13 +304,13 @@ const PLAN_DETAILS = {
     highlights: [
       'Branding removal',
       'Custom domains and SMTP',
-      'Invite unlimited users',
-      'SSO and enterprise identity controls',
+      'Add more than 2 users',
+      'SAML/LDAP and enterprise identity controls',
     ],
     summaryLine: 'Best when security, compliance, and centralized access control are non-negotiable.',
     features: [
       { icon: 'heroicons:globe-alt', title: 'Remove OpnForm branding', description: 'Publish forms without the OpnForm watermark and make the experience feel truly yours.' },
-      { icon: 'heroicons:shield-check', title: 'Enterprise SSO', description: 'Connect OIDC, SAML, or LDAP so access is controlled from your identity provider.' },
+      { icon: 'heroicons:shield-check', title: 'Enterprise SSO', description: 'Connect SAML or LDAP and add more than 2 users on your self-hosted instance.' },
       { icon: 'heroicons:document-text', title: 'Audit logs & compliance', description: 'Track important activity and support teams that need stronger internal controls.' },
     ],
   },

--- a/client/components/workspaces/settings/sso/Oidc.vue
+++ b/client/components/workspaces/settings/sso/Oidc.vue
@@ -105,7 +105,7 @@ const workspaceId = computed(() => workspace.value?.id)
 const { hasFeature } = usePlanFeatures()
 const canManageConnections = computed(() => !!workspace.value && workspace.value.is_admin)
 
-// Check if feature is accessible (Enterprise required for cloud, free for self-hosted)
+// OIDC is available on self-hosted instances; cloud workspaces still require Enterprise.
 const isSelfHosted = computed(() => useFeatureFlag('self_hosted'))
 const billingEnabled = computed(() => useFeatureFlag('billing.enabled'))
 const canAccessFeature = computed(() => {
@@ -115,7 +115,7 @@ const canAccessFeature = computed(() => {
 
 const { connections, create, update, remove } = useOidcConnections(workspaceId)
 
-// Allow viewing connections without Enterprise (Enterprise only required for create/update/delete)
+// Allow viewing connections without Enterprise (Enterprise only required for create/update/delete on cloud)
 const { data: connectionsData, isLoading: isConnectionsLoading } = connections()
 
 const alertConfig = computed(() => {
@@ -148,7 +148,7 @@ const alertConfig = computed(() => {
     icon: 'i-heroicons-information-circle',
     color: 'info',
     title: 'OIDC SSO',
-    description: 'Configure OpenID Connect single sign-on for your self-hosted installation.',
+    description: 'OIDC is available on self-hosted instances. Free self-hosted instances are limited to 2 users total; activate an Enterprise license to add more users.',
     actions: []
   }
 })
@@ -164,8 +164,8 @@ const openUpgradeModal = () => {
 const openSsoLicenseModal = (error) => {
   return handleLicenseError(error, {
     includeUnauthorized: true,
-    title: 'Enterprise license required for SSO',
-    description: 'Your self-hosted license does not include SSO. Purchase or activate an Enterprise self-hosted license to create and manage OIDC connections.'
+    title: 'Enterprise license required',
+    description: 'Activate an Enterprise self-hosted license to add more than 2 users or use advanced Enterprise features.'
   })
 }
 

--- a/client/pages/auth/[slug]/callback.vue
+++ b/client/pages/auth/[slug]/callback.vue
@@ -121,6 +121,8 @@ const handleCallback = async () => {
     if (errorResponse.error === 'oidc_account_link_required' && errorResponse.link_token) {
       error.value = 'An account with this email already exists. Please link your existing account to continue.'
       linkToken.value = errorResponse.link_token
+    } else if (errorMessage.includes('more than 2 users')) {
+      error.value = 'This self-hosted instance is limited to 2 users without an Enterprise license. Ask the instance admin to activate a license or remove another user.'
     } else if (errorMessage.includes('account with this email already exists')) {
       error.value = 'An account with this email already exists. Please contact your administrator to link your accounts.'
     } else if (errorMessage.includes('blocked')) {

--- a/client/pages/enterprise.vue
+++ b/client/pages/enterprise.vue
@@ -803,7 +803,7 @@ const enterpriseFaqs = [
   {
     question: "Does OpnForm support SSO?",
     answer:
-      "Yes. OpnForm supports enterprise identity controls including SSO options such as SAML and OIDC, depending on your setup and plan.",
+      "Yes. OpnForm supports SSO options such as OIDC and Enterprise SSO controls such as SAML, depending on your setup and plan.",
   },
   {
     question: "Where is form data hosted?",

--- a/client/pages/pricing.vue
+++ b/client/pages/pricing.vue
@@ -480,7 +480,7 @@
                     class="w-4 h-5 text-emerald-600"
                     name="heroicons:check-20-solid"
                   />
-                  SSO (SAML, OIDC, LDAP)
+                  SAML / LDAP SSO
                 </li>
                 <li class="flex items-center gap-2.5">
                   <Icon

--- a/client/public/llms.txt
+++ b/client/public/llms.txt
@@ -117,6 +117,8 @@ Use the technical documentation for implementation, configuration, embedding, AP
 
 - Technical docs introduction: https://docs.opnform.com/introduction
 - Cloud vs self-hosting: https://docs.opnform.com/deployment/cloud-vs-self-hosting
+- Self-hosted license: https://docs.opnform.com/deployment/self-hosted-license
+- License activation: https://docs.opnform.com/deployment/license-activation
 - Environment variables: https://docs.opnform.com/configuration/environment-variables
 - OAuth setup: https://docs.opnform.com/configuration/oauth-setup
 - AWS S3 setup: https://docs.opnform.com/configuration/aws-s3

--- a/docs/api-reference/endpoint/open-workspace-users.mdx
+++ b/docs/api-reference/endpoint/open-workspace-users.mdx
@@ -9,6 +9,8 @@ Authorization: Bearer <token with `workspace-users-read`>
 
 ## Add User to Workspace
 
+Self-hosted Community instances are limited to 2 users total across the whole instance. Adding or inviting a new user beyond that limit requires a self-hosted Enterprise license.
+
 ```http
 POST /open/workspaces/{workspaceId}/users/add HTTP/1.1
 Authorization: Bearer <token with `workspace-users-write`>

--- a/docs/api-reference/openapi.yaml
+++ b/docs/api-reference/openapi.yaml
@@ -155,7 +155,7 @@ paths:
             tags:
                 - Workspace Users
             summary: Add Workspace User
-            description: "Requires `workspace-users-write`. Add an existing user or send an invite if the email is unknown."
+            description: "Requires `workspace-users-write`. Add an existing user or send an invite if the email is unknown. Self-hosted Community instances are limited to 2 users total across the instance; adding or inviting more users requires a self-hosted Enterprise license."
             security:
                 - bearerAuth: []
             parameters:
@@ -184,7 +184,7 @@ paths:
                 "200":
                     description: User added
                 "403":
-                    description: Forbidden
+                    description: Forbidden, insufficient privileges, or self-hosted Community user limit reached
     "/open/workspaces/{workspaceId}/users/{userId}/remove":
         delete:
             tags:

--- a/docs/api-reference/workspace-users/add-workspace-user.mdx
+++ b/docs/api-reference/workspace-users/add-workspace-user.mdx
@@ -6,6 +6,10 @@ openapi: post /open/workspaces/{workspaceId}/users/add
 
 Invite an existing OpnForm user to a workspace or send an email invite if the user doesn't yet have an account.
 
+<Note>
+Self-hosted Community instances are limited to 2 users total across the whole instance. Adding or inviting a new user beyond that limit requires a self-hosted Enterprise license. Adding an existing instance user to another workspace does not consume an additional user seat.
+</Note>
+
 ## Authentication & Scope
 
 Requires the `workspace-users-write` ability and **admin** privileges in the workspace.
@@ -57,4 +61,4 @@ The response structure:
 }
 ```
 
-`403 Forbidden` – Token lacks `workspace-users-write` or insufficient privileges.
+`403 Forbidden` – Token lacks `workspace-users-write`, the requester has insufficient privileges, or the self-hosted Community instance has reached the 2-user limit.

--- a/docs/configuration/oidc-sso.mdx
+++ b/docs/configuration/oidc-sso.mdx
@@ -4,12 +4,11 @@ description: Complete guide to configuring OpenID Connect Single Sign-On for you
 ---
 
 <Info>
-    **Enterprise Feature**: OIDC SSO is part of OpnForm Enterprise. On
-    self-hosted installations, configure an active Enterprise license before
-    creating or updating workspace OIDC connections. For more information about
-    Enterprise licensing, see our [Enterprise
-    Terms](https://opnform.com/terms-conditions) and [License
-    Activation](/deployment/license-activation).
+    **Self-hosted availability**: OIDC SSO is available on self-hosted
+    installations without an Enterprise license. Free self-hosted instances are
+    limited to 2 users total across the whole instance, regardless of whether
+    users are created by registration, invitations, or OIDC provisioning. An
+    Enterprise license is required to add more users.
 </Info>
 
 OpnForm supports OpenID Connect (OIDC) based Single Sign-On (SSO), allowing users to authenticate using their organization's identity provider (IdP) such as Azure Entra ID, Authentik, Okta, or any OIDC-compliant provider.
@@ -36,6 +35,13 @@ Before setting up OIDC SSO, ensure you have:
 2. OAuth client credentials (Client ID and Client Secret) from your IdP
 3. Admin access to the workspace where you want to configure SSO
 4. The issuer URL from your IdP (typically found in the `.well-known/openid-configuration` endpoint)
+
+<Note>
+    On self-hosted Community instances, OIDC can provision users until the
+    instance reaches the free 2-user limit. Existing linked users can continue
+    signing in with OIDC. Activate a self-hosted Enterprise license to add more
+    than 2 users.
+</Note>
 
 ## Setup Steps
 

--- a/docs/deployment/cloud-vs-self-hosting.mdx
+++ b/docs/deployment/cloud-vs-self-hosting.mdx
@@ -7,26 +7,29 @@ When deciding between using OpnForm's cloud service or self-hosting, it's import
 
 <Info>
     Self-hosting OpnForm does not require an Enterprise license for core
-    functionality. Some advanced workspace features require a self-hosted
-    Enterprise license. See [Self-hosted
+    functionality. Free self-hosted instances include OIDC within a 2-user
+    instance limit. Adding more users and some advanced workspace features
+    require a self-hosted Enterprise license. See [Self-hosted
     License](/deployment/self-hosted-license).
 </Info>
 
-|                         | Self-Hosted                         | OpnForm Cloud                      |
-| ------------------------------ | ----------------------------------- | ---------------------------------- |
-| High availability servers      | \~$50+/month                        | ✅                                 |
-| Load balancer                  | \~$15+/month                        | ✅                                 |
-| Managed database               | \~$45-70+/month                     | ✅                                 |
-| Instance-wide SMTP provider    | \~$15+/month                        | ✅                                 |
-| Support                        | Discord                    | Live Chat                     |
-| Setup time                     | Manual                              | ✅ Up and running in minutes       |
-| Upgrades                       | Manual                              | ✅ Automatic                       |
-| Multi-zone availability        | Manual                              | ✅                                 |
-| Backups                        | Manual                              | ✅ Automatic                       |
-| Monitoring                     | Manual                              | ✅                                 |
-| Custom code and forks          | ✅                                  | ❌                                 |
-| SSL certificate                | Manual                              | ✅                                 |
-| Where your money goes              | 3rd-party services                  | Improving OpnForm   |
+|                            | Self-Hosted                                      | OpnForm Cloud                      |
+| -------------------------- | ------------------------------------------------ | ---------------------------------- |
+| High availability servers  | \~$50+/month                                     | ✅                                 |
+| Load balancer              | \~$15+/month                                     | ✅                                 |
+| Managed database           | \~$45-70+/month                                  | ✅                                 |
+| Instance-wide SMTP provider | \~$15+/month                                    | ✅                                 |
+| Users                      | 2 users free; Enterprise license for more users  | Based on cloud plan                |
+| OIDC SSO                   | Included within the 2-user free self-hosted limit | Based on cloud plan                |
+| Support                    | Discord                                          | Live Chat                          |
+| Setup time                 | Manual                                           | ✅ Up and running in minutes       |
+| Upgrades                   | Manual                                           | ✅ Automatic                       |
+| Multi-zone availability    | Manual                                           | ✅                                 |
+| Backups                    | Manual                                           | ✅ Automatic                       |
+| Monitoring                 | Manual                                           | ✅                                 |
+| Custom code and forks      | ✅                                               | ❌                                 |
+| SSL certificate            | Manual                                           | ✅                                 |
+| Where your money goes      | 3rd-party services                               | Improving OpnForm                  |
 
 ### When Should You Self-Host?
 

--- a/docs/deployment/docker-development.mdx
+++ b/docs/deployment/docker-development.mdx
@@ -57,7 +57,9 @@ After starting the development environment, OpnForm will automatically redirect 
 
 <Note>
     Public registration is disabled in the self-hosted version after setup is
-    complete. Use the admin account to invite additional users.
+    complete. Use the admin account to invite additional users. Free
+    self-hosted instances are limited to 2 users total across the instance;
+    activate a self-hosted Enterprise license to add more users.
 </Note>
 
 ## Architecture

--- a/docs/deployment/docker.mdx
+++ b/docs/deployment/docker.mdx
@@ -52,13 +52,16 @@ After deployment, OpnForm will automatically redirect you to a setup page where 
 
 <Note>
     Public registration is disabled in the self-hosted version after setup is
-    complete. Use the admin account to invite additional users.
+    complete. Use the admin account to invite additional users. Free
+    self-hosted instances are limited to 2 users total across the instance;
+    activate a self-hosted Enterprise license to add more users.
 </Note>
 
 <Info>
     A self-hosted Enterprise license is optional. Core self-hosted OpnForm works
-    without a license, while advanced Enterprise features require license
-    activation. See [Self-hosted License](/deployment/self-hosted-license).
+    without a license, including OIDC within the free 2-user limit. Adding more
+    users and advanced Enterprise features require license activation. See
+    [Self-hosted License](/deployment/self-hosted-license).
 </Info>
 
 ## Architecture

--- a/docs/deployment/enterprise-features/multiple-workspaces.mdx
+++ b/docs/deployment/enterprise-features/multiple-workspaces.mdx
@@ -5,11 +5,19 @@ description: Use Enterprise multi-workspace and team role controls on self-hoste
 
 Self-hosted Enterprise can unlock workspace and team administration features for organizations that manage several teams, clients, or departments in one OpnForm instance.
 
+<Info>
+    Self-hosted Community instances are limited to 2 users total across the
+    whole instance. A self-hosted Enterprise license is required to add more
+    than 2 users, whether users are invited manually or provisioned through
+    OIDC.
+</Info>
+
 ## What this unlocks
 
 Depending on the features included in your license, multi-org access can unlock:
 
 -   Multiple workspaces
+-   More than 2 users across the instance
 -   Advanced workspace member roles
 -   Higher-level organization controls around workspace administration
 

--- a/docs/deployment/enterprise-features/single-sign-on.mdx
+++ b/docs/deployment/enterprise-features/single-sign-on.mdx
@@ -3,23 +3,29 @@ title: Single Sign-On
 description: Use Enterprise SSO features on self-hosted OpnForm
 ---
 
-Self-hosted Enterprise can unlock SSO features for teams that need centralized identity management.
+Self-hosted Enterprise unlocks advanced SSO features for teams that need centralized identity management beyond the Community self-hosted limits.
+
+<Info>
+    OIDC SSO is available on self-hosted Community instances without an
+    Enterprise license, but the instance remains limited to 2 users total.
+    Enterprise is required to add more than 2 users and to use SAML or LDAP SSO.
+</Info>
 
 ## What this unlocks
 
 Enterprise SSO covers:
 
--   OIDC SSO
 -   SAML SSO
 -   LDAP SSO
+-   More than 2 self-hosted users when using OIDC provisioning
 
-OIDC configuration is currently documented in detail. SAML and LDAP availability depends on the Enterprise features enabled for your installation.
+OIDC configuration is documented in detail and can be used on Community self-hosted instances within the 2-user limit. SAML and LDAP availability depends on the Enterprise features enabled for your installation.
 
 ## Before you start
 
 Make sure you have:
 
--   An active self-hosted Enterprise license with SSO enabled
+-   An active self-hosted Enterprise license with SSO enabled for SAML or LDAP
 -   Workspace admin access
 -   Identity provider credentials and allowed redirect URI configuration
 

--- a/docs/deployment/license-activation.mdx
+++ b/docs/deployment/license-activation.mdx
@@ -3,7 +3,14 @@ title: License Activation
 description: Activate a self-hosted Enterprise license on your OpnForm installation
 ---
 
-Use a self-hosted Enterprise license key to unlock Enterprise features on your OpnForm instance.
+Use a self-hosted Enterprise license key to unlock Enterprise features and add more than 2 users on your OpnForm instance.
+
+<Info>
+    Self-hosted Community instances can be used without an Enterprise license
+    for up to 2 users total across the instance. OIDC SSO is available within
+    that 2-user limit. Activate a self-hosted Enterprise license to add more
+    users or use licensed Enterprise features.
+</Info>
 
 ## Prerequisites
 

--- a/docs/deployment/self-hosted-license.mdx
+++ b/docs/deployment/self-hosted-license.mdx
@@ -21,7 +21,10 @@ OpnForm also includes Enterprise features under a separate Enterprise License. T
 | Run OpnForm for commercial use | Yes | Yes |
 | Modify the AGPLv3 core and redistribute under AGPLv3 | Yes | Yes |
 | Use core form builder features | Yes | Yes |
+| Use up to 2 users across the instance | Yes | Yes |
+| Add more than 2 users across the instance | No | Yes |
 | Configure instance-wide SMTP, storage, domains, and OAuth | Yes | Yes |
+| Use OIDC SSO | Yes, within the 2-user limit | Yes |
 | Use Enterprise workspace features | No | Yes |
 | Use Enterprise support and licensing terms | No | Yes |
 
@@ -37,8 +40,9 @@ Community self-hosted installations include the core OpnForm product:
 -   Instance-wide domain configuration with `APP_URL`, `FRONT_URL`, and your reverse proxy
 -   Instance-wide file storage configuration, including local and S3-compatible storage
 -   Standard authentication and OAuth providers configured with environment variables
+-   OIDC SSO for up to 2 users across the instance
 
-The exact limits depend on your infrastructure and on the product features enabled in your version of OpnForm.
+Free self-hosted instances are limited to 2 users total across the whole instance. This limit applies regardless of how users are added: registration, invitations, or OIDC provisioning.
 
 ## What is included in self-hosted Enterprise?
 
@@ -46,7 +50,7 @@ Self-hosted Enterprise unlocks advanced workspace and organization controls:
 
 | Enterprise area | What it unlocks |
 | --------------- | --------------- |
-| SSO | OIDC, SAML, and LDAP single sign-on features |
+| SSO | SAML and LDAP single sign-on features; OIDC remains available on Community self-hosted within the 2-user limit |
 | Multi-org | Multiple workspaces and advanced team role features |
 | White label | Branding removal, advanced branding, and white-label controls |
 | Workspace Custom SMTP | Dedicated SMTP settings for individual workspaces |
@@ -68,7 +72,7 @@ Some OpnForm settings exist at two levels. The instance-wide configuration is av
 | Email | Configure the default sender with `MAIL_*` variables | Configure Workspace Custom SMTP for a specific workspace |
 | Storage | Configure the default filesystem or S3-compatible storage | Use Enterprise external storage controls when available |
 | Branding | Use core form customization options | Remove OpnForm branding and use advanced white-label controls |
-| Authentication | Use standard login and configured OAuth providers | Use OIDC, SAML, or LDAP SSO |
+| Authentication | Use standard login, configured OAuth providers, and OIDC within the 2-user limit | Use SAML/LDAP SSO and add more than 2 users |
 
 <Note>
     Custom domains can also exist at two levels: the domain for your whole

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -11,8 +11,10 @@ OpnForm is an open-source form builder designed to empower developers and users 
 
 <Info>
   Self-hosted OpnForm can be used without an Enterprise license for core
-  functionality. Advanced self-hosted features require license activation. See
-  [Self-hosted License](/deployment/self-hosted-license).
+  functionality. Free self-hosted instances include OIDC within a 2-user
+  instance limit. Adding more users and advanced self-hosted features require
+  license activation. See [Self-hosted
+  License](/deployment/self-hosted-license).
 </Info>
 
 <CardGroup cols={2}>


### PR DESCRIPTION
## Summary
- allow OIDC connection management on self-hosted instances without requiring an Enterprise license
- enforce the free self-hosted 2-user instance limit across registration, invites, and OIDC provisioning
- clarify self-hosted licensing, OIDC, SAML/LDAP, user limits, and API docs
- move Stripe export lookback configuration from env() usage into Laravel config so Larastan passes

## Validation
- vendor/bin/pest --filter=ProvisioningServiceTest
- vendor/bin/pest --filter=IdentityConnectionPolicyTest
- vendor/bin/pest --filter=OidcConnectionControllerTest
- vendor/bin/pest --filter=RegisterTest
- vendor/bin/pest --filter=WorkspaceInviteLimitTest
- vendor/bin/pest --filter=LicenseServiceTest
- npm run lint
- npm run test -- test/nuxt/oidc-link-flow.spec.ts
- npm run test -- test/unit/oidc-connection-options.test.ts
- ./vendor/bin/phpstan analyse --memory-limit=2G
- git diff --check
- docs.json parse check

## Notes
- OpenAPI YAML parser packages were not available locally, so the YAML file was reviewed and updated but not parser-validated.