### PR TITLE
[codex] Fix public submission ID fallback

### DIFF
--- a/api/app/Http/Controllers/Forms/PublicFormController.php
+++ b/api/app/Http/Controllers/Forms/PublicFormController.php
@@ -253,6 +253,7 @@ class PublicFormController extends Controller
         }
 
         // Legacy Hashid support (backward compatibility)
+        unset($submissionData['submission_id'], $submissionData['submission_hash']);
         $decodedId = Hashids::decode($submissionIdentifier);
         if (!empty($decodedId)) {
             $numericId = (int)($decodedId[0] ?? null);
@@ -266,7 +267,6 @@ class PublicFormController extends Controller
                 }
             }
         }
-        unset($submissionData['submission_hash']);
 
         return $submissionData;
     }

--- a/api/tests/Feature/Forms/SubmissionIdentifierTest.php
+++ b/api/tests/Feature/Forms/SubmissionIdentifierTest.php
@@ -88,6 +88,32 @@ describe('Submission UUID Identifiers', function () {
         // Verify only one submission exists (was updated, not created new)
         expect($this->form->submissions()->count())->toBe(1);
     });
+
+    it('does not allow editing submission using raw numeric id', function () {
+        $nameField = collect($this->form->properties)->where('name', 'Name')->first();
+
+        $initialData = $this->generateFormSubmissionData($this->form, [
+            $nameField['id'] => 'ORIGINAL_DATA',
+        ]);
+        $this->postJson(route('forms.answer', $this->form), $initialData)
+            ->assertSuccessful();
+
+        $submission = $this->form->submissions()->first();
+
+        $editData = $this->generateFormSubmissionData($this->form, [
+            $nameField['id'] => 'POISONED_DATA',
+        ]);
+        $editData['submission_id'] = (string) $submission->id;
+
+        $this->actingAsGuest();
+        $this->postJson(route('forms.answer', $this->form), $editData)
+            ->assertSuccessful();
+
+        expect($this->form->submissions()->count())->toBe(2);
+
+        $submission->refresh();
+        expect($submission->data[$nameField['id']])->toBe('ORIGINAL_DATA');
+    });
 });
 
 describe('Legacy Hashid Backward Compatibility', function () {

--- a/api/tests/Feature/Submissions/PartialSubmissionTest.php
+++ b/api/tests/Feature/Submissions/PartialSubmissionTest.php
@@ -76,6 +76,76 @@ it('can update partial submission multiple times', function () {
     expect($submission->data[array_key_first($secondData)])->toBe('Second Draft');
 });
 
+it('does not update a partial submission from a raw numeric submission id', function () {
+    $user = $this->actingAsBusinessUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace, [
+        'enable_partial_submissions' => true
+    ]);
+    $nameField = collect($form->properties)->where('name', 'Name')->first();
+
+    $this->actingAsGuest();
+
+    $victimData = $this->generateFormSubmissionData($form, [
+        $nameField['id'] => 'VICTIM_CONFIDENTIAL_DATA',
+    ]);
+    $victimData['is_partial'] = true;
+
+    $this->postJson(route('forms.answer', $form->slug), $victimData)
+        ->assertSuccessful();
+
+    $victimSubmission = $form->submissions()->first();
+
+    $attackData = $this->generateFormSubmissionData($form, [
+        $nameField['id'] => 'ATTACKER_POISONED_DATA',
+    ]);
+    $attackData['is_partial'] = true;
+    $attackData['submission_id'] = (string) $victimSubmission->id;
+
+    $this->postJson(route('forms.answer', $form->slug), $attackData)
+        ->assertSuccessful();
+
+    expect($form->submissions()->count())->toBe(2);
+
+    $victimSubmission->refresh();
+    expect($victimSubmission->data[$nameField['id']])->toBe('VICTIM_CONFIDENTIAL_DATA');
+});
+
+it('does not update a completed submission from a raw numeric submission id in a partial request', function () {
+    $user = $this->actingAsBusinessUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace, [
+        'enable_partial_submissions' => true
+    ]);
+    $nameField = collect($form->properties)->where('name', 'Name')->first();
+
+    $this->actingAsGuest();
+
+    $completedData = $this->generateFormSubmissionData($form, [
+        $nameField['id'] => 'COMPLETED_ORIGINAL_DATA',
+    ]);
+
+    $this->postJson(route('forms.answer', $form->slug), $completedData)
+        ->assertSuccessful();
+
+    $completedSubmission = $form->submissions()->first();
+
+    $attackData = $this->generateFormSubmissionData($form, [
+        $nameField['id'] => 'ATTACKER_POISONED_DATA',
+    ]);
+    $attackData['is_partial'] = true;
+    $attackData['submission_id'] = (string) $completedSubmission->id;
+
+    $this->postJson(route('forms.answer', $form->slug), $attackData)
+        ->assertSuccessful();
+
+    expect($form->submissions()->count())->toBe(2);
+
+    $completedSubmission->refresh();
+    expect($completedSubmission->status)->toBe(FormSubmission::STATUS_COMPLETED);
+    expect($completedSubmission->data[$nameField['id']])->toBe('COMPLETED_ORIGINAL_DATA');
+});
+
 it('calculates stats correctly for partial vs completed submissions', function () {
     $user = $this->actingAsBusinessUser();
     $workspace = $this->createUserWorkspace($user);


### PR DESCRIPTION
## Summary

Fixes the public form submission identifier fallback so raw numeric `submission_id` values are not forwarded to `StoreFormSubmissionJob` from the public answer endpoint.

Only identifiers that successfully resolve through the supported public formats, UUID or legacy Hashid, can be converted into an internal submission ID. Unresolved identifiers are now stripped, so the request creates a new submission instead of updating an existing one.

## Root Cause

`PublicFormController::processSubmissionIdentifiers()` removed `submission_hash` after the legacy Hashid fallback, but left `submission_id` in the payload when the supplied value did not resolve as either a UUID or Hashid. The storage job later treated numeric `submission_id` values as raw database IDs.

## User Impact

Supported OpnForm flows continue to use UUIDs, legacy Hashids, or `submission_hash`. The behavior change is limited to public requests that send raw numeric internal IDs, which should not be a supported public update mechanism.

## Tests

- `composer install --no-interaction --no-progress`
- `./vendor/bin/pest tests/Feature/Submissions/PartialSubmissionTest.php tests/Feature/Forms/SubmissionIdentifierTest.php tests/Feature/Forms/FormUpdateTest.php tests/Feature/Forms/FormSubmissionProcessorTest.php tests/Feature/Submissions/EditSubmissionTest.php`
- `./vendor/bin/pint --test app/Http/Controllers/Forms/PublicFormController.php tests/Feature/Submissions/PartialSubmissionTest.php tests/Feature/Forms/SubmissionIdentifierTest.php`