### PR TITLE
[codex] Make Enterprise pricing self-serve

### DIFF
--- a/client/components/pages/pricing/SubscriptionModal.vue
+++ b/client/components/pages/pricing/SubscriptionModal.vue
@@ -507,12 +507,6 @@ const startCheckout = async (planName) => {
     return
   }
 
-  if(planName === 'enterprise') {
-    closeModal()
-    useCrisp().openAndShowChat()
-    return
-  }
-
   currentPlan.value = planName
 
   try {

--- a/client/pages/pricing.vue
+++ b/client/pages/pricing.vue
@@ -460,9 +460,9 @@
               <UButton
                 class="w-fit sm:w-full justify-center px-4 py-2.5 rounded-[12px] text-base leading-7 tracking-[-1.1%] font-medium"
                 variant="outline"
-                label="Request a quote"
+                label="Get started free"
                 color="neutral"
-                @click.prevent="contactUs"
+                @click.prevent="handleEnterpriseCta"
               />
             </div>
 
@@ -916,8 +916,5 @@ const handlePlanCta = (plan) => {
 
 const handleProCta = () => handlePlanCta("pro")
 const handleBusinessCta = () => handlePlanCta("business")
-
-const contactUs = () => {
-  useCrisp().openAndShowChat()
-}
+const handleEnterpriseCta = () => handlePlanCta("enterprise")
 </script>


### PR DESCRIPTION
## Summary

Updates the hosted pricing flow so the Enterprise plan behaves like the other self-serve paid plans.

## What changed

- Replaced the Enterprise pricing page CTA from `Request a quote` to `Get started free`.
- Routed Enterprise CTA clicks through the existing subscription modal flow.
- Removed the special-case Enterprise checkout interception that opened Crisp instead of Stripe checkout.

## Why

Enterprise pricing already has configured plan pricing and should be self-served. The previous UI still treated it as a quote/contact-sales flow.

## Validation

- `npm run lint` in `client/`